### PR TITLE
Add .gitignore file into the project folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Bazel symlinks.
+/bazel-*
+
+# IntelliJ IDEA
+*/.idea
+out/
+
+# Bazel Plugin for IntelliJ IDEA
+*/.ijwb


### PR DESCRIPTION
Add .gitignore file to exclude adding `IntelliJ IDEA` and `Bazel` output files into future PRs

* According to `Bazel` documentation symlinks _“bazel-<workspace-name>”, “bazel-out”, “bazel-testlogs”,_ and _“bazel-bin”_ in the workspace directory point to some directories inside the output directory. `Bazel` doesn't use them and they are reconfigured after each build, so there is no sense to include them.
* Since build system `Bazel` is chosen for project, adding _.idea_ files makes no sense.