### PR TITLE
Added third-party protobuf library 📌

### DIFF
--- a/project/third_party/java/protobuf/BUILD
+++ b/project/third_party/java/protobuf/BUILD
@@ -1,10 +1,10 @@
-# Copyright 2020 Google LLC
+# Copyright (C) 2018 The Google Bazel Common Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,18 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_plugin")
-load("@dagger//:workspace_defs.bzl", "dagger_rules")
+# BUILD rules for https://github.com/google/protobuf/tree/master/java
 
-dagger_rules()
+load("@rules_java//java:defs.bzl", "java_library")
 
-java_plugin(
-    name = "dagger_query_plugin",
-    srcs = glob(["src/com/google/daggerquery/**/*.java"]),
-    deps = [
-        "//:dagger-spi",
-        "//third_party/java/auto:service",
-        "//third_party/java/protobuf:protobuf",
-    ]
+package(default_visibility = ["//visibility:public"])
+
+java_library(
+    name = "protobuf",
+    exports = ["@com_google_protobuf_protobuf_java//jar"],
 )
-

--- a/project/workspace_defs.bzl
+++ b/project/workspace_defs.bzl
@@ -48,6 +48,8 @@ def google_common_workspace_rules():
     //third_party.
     """
 
+    # Import AutoService
+
     _maven_import(
         artifact = "com.google.auto:auto-common:0.10",
         licenses = ["notice"],
@@ -59,4 +61,20 @@ def google_common_workspace_rules():
         licenses = ["notice"],
         sha256 = "e422d49c312fd2031222e7306e8108c1b4118eb9c049f1b51eca280bed87e924",
     )
+
+    # Import Protocol Buffers
+
+    _maven_import(
+        artifact = "com.google.protobuf:protobuf-java:3.12.0",
+        licenses = ["notice"],
+        sha256 = "dc7f93e3a3dc2c11be5ba9672af3e26410f0a3289312dbf2260d4d8a0c711a51",
+    )
+
+    for protobuf_repo in ("com_google_protobuf", "com_google_protobuf_java"):
+        http_archive(
+            name = protobuf_repo,
+            sha256 = "9748c0d90e54ea09e5e75fb7fac16edce15d2028d4356f32211cfa3c0e956564",
+            strip_prefix = "protobuf-3.11.4",
+            urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.12.0.zip"],
+        )
 


### PR DESCRIPTION
Add dependency for `protocol buffers` (version 3.12.0)

[Card](https://github.com/googleinterns/dagger-query/projects/1#card-42487416)