### PR TITLE
Added bazel rule with example to test graph serialization

### DIFF
--- a/project/src/com/google/daggerquery/BUILD
+++ b/project/src/com/google/daggerquery/BUILD
@@ -20,4 +20,3 @@ java_plugin(
         "//src/com/google/daggerquery/plugin:plugin_sources",
     ]
 )
-

--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -1,0 +1,42 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def dagger_query_textproto(name, dagger_app_target):
+    _dagger_query_textproto(name = name, dagger_app_target = dagger_app_target)
+
+def _dagger_query_textproto_impl(ctx):
+    dagger_app_target = ctx.attr.dagger_app_target
+    src_jars = dagger_app_target[JavaInfo].source_jars
+
+    ctx.actions.run_shell(
+        inputs = src_jars,
+        outputs = [ctx.outputs.out],
+        command = "unzip -p {src_jar} binding_graph.textproto > {out}".format(
+            src_jar = src_jars[0].path,
+            out = ctx.outputs.out.path,
+        ),
+    )
+
+_dagger_query_textproto = rule(
+    attrs = {
+        "dagger_app_target": attr.label(
+            mandatory = True,
+            providers = [JavaInfo]
+        ),
+    },
+    outputs = {
+        "out": "%{name}.textproto",
+    },
+    implementation = _dagger_query_textproto_impl,
+)

--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -19,6 +19,9 @@ def _dagger_query_textproto_impl(ctx):
     dagger_app_target = ctx.attr.dagger_app_target
     src_jars = dagger_app_target[JavaInfo].source_jars
 
+    if len(src_jars) != 1:
+        fail("Found multiple jars with sources")
+
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],


### PR DESCRIPTION
Add bazel rule to extract `.textproto` file from app jar

Now all process looks like this:
* In dagger spi plugin with `Filer` instance we save a file with binding graph to `binding_graph.textproto`
* This file with graph appears in main app's jar
* With rule `dagger_query_textproto` we extract file from this jar and now able to add it to any other target 🎉 