### PR TITLE
Supported ALLPATHS query 🚀

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -132,7 +132,7 @@ public class Query {
    *
    * <p>Uses delimiter '->' for constructing the string representation of all data.
    */
-  private class Path<NodeT> {
+  private static class Path<NodeT> {
     private Deque<NodeT> nodesDeque = new ArrayDeque<>();
 
     Path() {

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -95,18 +95,23 @@ public class Query {
    * </ul>
    */
   public List<String> execute(BindingGraph bindingGraph) {
-    String source = parameters[0];
-
-    if (!bindingGraph.getAdjacencyListMap().containsKey(source)) {
-      throw new IllegalArgumentException("Specified source node doesn't exist.");
-    }
-
     switch (name) {
       case DEPS_QUERY_NAME:
-        return bindingGraph.getAdjacencyListMap().get(source).getDependencyList()
-            .stream().map(Dependency::getTarget).sorted().collect(toList());
+        String sourceNode = parameters[0];
 
+        if (!bindingGraph.getAdjacencyListMap().containsKey(sourceNode)) {
+          throw new IllegalArgumentException("Specified source node doesn't exist.");
+        }
+
+        return bindingGraph.getAdjacencyListMap().get(sourceNode).getDependencyList()
+            .stream().map(Dependency::getTarget).sorted().collect(toList());
       case ALLPATHS_QUERY_NAME:
+        String source = parameters[0];
+
+        if (!bindingGraph.getAdjacencyListMap().containsKey(source)) {
+          throw new IllegalArgumentException("Specified source node doesn't exist.");
+        }
+
         String target = parameters[1];
         Set<String> visitedNodes = new HashSet<>();
         List<List<String>> result = new ArrayList<>();

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -86,8 +86,14 @@ public class Query {
   /**
    * Executes query on a {@link BindingGraph}.
    *
-   * <p>For all queries return a list with string. Strings content depends on a query name.
-   * <p>For `deps` queries each string represent exactly one dependency.
+   * <p>For all queries return a list with strings. Strings content depends on a query name.
+   *
+   * <ul>
+   * <li>For `deps` query each string represent exactly one dependency.
+   * <li>For `allpaths` query each string contains a path between {@code source} and {@code target} nodes.
+   * The connection between nodes is shown with construction '->'. For example, one of the possible paths
+   * may look like this: "com.google.First -> com.google.Second -> com.google.Third".
+   * </ul>
    */
   public List<String> execute(BindingGraph bindingGraph) {
     String source = parameters[0];
@@ -114,6 +120,16 @@ public class Query {
     throw new NotImplementedException();
   }
 
+  /**
+   * Traverses a {@link BindingGraph} starting from {@code source} node.
+   *
+   * <p>Puts all processed nodes in a {@code visitedNodes} set to avoid loops. Constructs a {@code path} which is
+   * an instance of {@link List<String>}. At each recursive level this variable contains a correct path in a graph from
+   * some root node which was passed in the first call and {@code target} node which is the same for all calls.
+   *
+   * <p>As the result fills provided {@link List<List<String>>} {@code allPaths} with all possible paths between
+   * root and target nodes.
+   */
   private void findAllPaths(String source, String target, List<String> path, BindingGraph bindingGraph,
                             Set<String> visitedNodes, List<List<String>> allPaths) {
     path.add(source);
@@ -126,7 +142,6 @@ public class Query {
     }
 
     visitedNodes.add(source);
-    System.out.println(String.format("Visiting %s", source));
     for (Dependency nextNode: bindingGraph.getAdjacencyListMap().get(source).getDependencyList()) {
       if (visitedNodes.contains(nextNode.getTarget())) {
         continue;

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -86,12 +86,12 @@ public class Query {
   /**
    * Executes query on a {@link BindingGraph}.
    *
-   * <p>For all queries return a list with strings. Strings content depends on a query name.
+   * <p>For all queries return a list with strings. The content of the strings depends on a query name.
    *
    * <ul>
-   * <li>For `deps` query each string represent exactly one dependency.
+   * <li>For `deps` query each string represents exactly one dependency.
    * <li>For `allpaths` query each string contains a path between {@code source} and {@code target} nodes.
-   * The connection between nodes is shown with construction '->'. For example, one of the possible paths
+   * The connection between nodes is shown with the construction '->'. For example, one of the possible paths
    * may look like this: "com.google.First -> com.google.Second -> com.google.Third".
    * </ul>
    */

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -16,6 +16,7 @@ limitations under the License.
 
 package com.google.daggerquery.executor.models;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto.BindingGraph;
 import com.google.daggerquery.protobuf.autogen.DependencyProto.Dependency;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
@@ -45,12 +46,10 @@ public class Query {
    * The key is the name of supported query and the value is the number of parameters,
    * required by query with such name.
    */
-  private final static Map<String, Integer> supportedQueries = new HashMap<String, Integer>() {
-    {
-      put(DEPS_QUERY_NAME, 1);
-      put(ALLPATHS_QUERY_NAME, 2);
-    }
-  };
+  private final static ImmutableMap<String, Integer> supportedQueries = ImmutableMap.<String, Integer>builder()
+      .put(DEPS_QUERY_NAME, 1)
+      .put(ALLPATHS_QUERY_NAME, 2)
+      .build();
 
   private String name;
   private String[] parameters;

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -215,7 +215,7 @@ public class QueryTest {
         .addDependency(factoryNode)
         .addDependency(helperNode)
         .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies factoryNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
+    BindingGraphProto.BindingGraph.ListWithDependencies catsFactoryNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
         .addDependency(catNode)
         .build();
     BindingGraphProto.BindingGraph.ListWithDependencies catNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
@@ -225,7 +225,7 @@ public class QueryTest {
 
     return BindingGraphProto.BindingGraph.newBuilder()
         .putAdjacencyList("com.google.Component", componentNodeDeps)
-        .putAdjacencyList("com.google.CatsFactory", factoryNodeDeps)
+        .putAdjacencyList("com.google.CatsFactory", catsFactoryNodeDeps)
         .putAdjacencyList("com.google.Cat", catNodeDeps)
         .putAdjacencyList("com.google.Helper", helperNodeDeps)
         .build();
@@ -251,7 +251,7 @@ public class QueryTest {
         .addDependency(catNode)
         .addDependency(detailsNode)
         .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies factoryNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
+    BindingGraphProto.BindingGraph.ListWithDependencies catsFactoryNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
         .addDependency(catNode)
         .build();
     BindingGraphProto.BindingGraph.ListWithDependencies helperNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
@@ -265,7 +265,7 @@ public class QueryTest {
 
     return BindingGraphProto.BindingGraph.newBuilder()
         .putAdjacencyList("com.google.Component", componentNodeDeps)
-        .putAdjacencyList("com.google.CatsFactory", factoryNodeDeps)
+        .putAdjacencyList("com.google.CatsFactory", catsFactoryNodeDeps)
         .putAdjacencyList("com.google.Helper", helperNodeDeps)
         .putAdjacencyList("com.google.Cat", catNodeDeps)
         .putAdjacencyList("com.google.Details", detailsNodeDeps)

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -28,12 +28,12 @@ import java.util.List;
 
 public class QueryTest {
 
-  // Tests for `DEPS` query
-
   @Test(expected = NullPointerException.class)
   public void testParsingQuery_WithNullQueryTypeName_ThrowsNullPointerException() {
     Query query = new Query(/*typeName = */ null, "com.google.cats.Cat");
   }
+
+  // Tests for `DEPS` query
 
   @Test(expected = IllegalArgumentException.class)
   public void testParsingDepsQuery_WithTwoStringParameters_ThrowsIllegalArgumentException() {

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -18,8 +18,8 @@ package com.google.daggerquery.executor.models;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-
+import static org.junit.Assert.assertTrue;
+import com.google.common.collect.Lists;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto;
 import com.google.daggerquery.protobuf.autogen.DependencyProto;
 import org.junit.Test;
@@ -155,13 +155,15 @@ public class QueryTest {
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
 
-    String[] expectedOutput = {
-        "com.google.Component -> com.google.CatsFactory -> com.google.Cat -> com.google.Details",
-        "com.google.Component -> com.google.Helper -> com.google.CatsFactory -> com.google.Cat -> com.google.Details",
+    List<String> expectedOutput = Lists.newArrayList(
+        "com.google.Component -> com.google.Details",
         "com.google.Component -> com.google.Cat -> com.google.Details",
-        "com.google.Component -> com.google.Details"
-    };
-    assertArrayEquals(expectedOutput, queryExecutionResult.toArray());
+        "com.google.Component -> com.google.CatsFactory -> com.google.Cat -> com.google.Details",
+        "com.google.Component -> com.google.Helper -> com.google.CatsFactory -> com.google.Cat -> com.google.Details"
+    );
+
+    assertTrue(expectedOutput.size() == queryExecutionResult.size());
+    assertTrue(queryExecutionResult.containsAll(expectedOutput) && expectedOutput.containsAll(queryExecutionResult));
   }
 
   @Test

--- a/project/tests/com/google/daggerquery/plugin/GraphConverterTest.java
+++ b/project/tests/com/google/daggerquery/plugin/GraphConverterTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.util.Map;
 


### PR DESCRIPTION
Support `allpaths` query and cover it with tests

#### Main changes in this PR:
1. Added two constants for containing queries names in `Query` class to avoid using simple strings several times in code.
2. Extended `public execute(...)` method in `Query` class with logic for executing **allpaths** query.
3.  Implemented helper method `findAllPaths(...)` in `Query` class which recursively traverses a graph and constructs all possible pathes.
4. Added tests into `QueryTest` class.

[Card №1](https://github.com/googleinterns/dagger-query/projects/1#card-42487520)
[Card №2](https://github.com/googleinterns/dagger-query/projects/1#card-42487638)