### PR TITLE
Added missing Guava dependency

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/BUILD
+++ b/project/src/com/google/daggerquery/executor/models/BUILD
@@ -22,5 +22,6 @@ java_library(
     deps = [
         "//src/com/google/daggerquery/protobuf:binding_graph_java_proto",
         "//src/com/google/daggerquery/protobuf:dependency_java_proto",
+        "//third_party/java/guava:guava"
     ],
 )


### PR DESCRIPTION
Fixes #15 with adding missing Guava dependency

In the previous PR required **Guava** dependency was not committed and missed.
Now build is fixed: [dagger-query/builds/70](https://buildkite.com/bazel/dagger-query/builds/70).