### PR TITLE
Serialize all binding graphs into different files and pack them into one .zip archive 👩‍💻

### DIFF
--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -25,7 +25,7 @@ def _dagger_query_textproto_impl(ctx):
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],
-        command = "unzip -p {src_jar} binding_graph.textproto > {out}".format(
+        command = "touch {out}; unzip {src_jar}; for FILE in *.textproto; do cat $FILE >> {out}; done".format(
             src_jar = src_jars[0].path,
             out = ctx.outputs.out.path,
         ),

--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -25,7 +25,7 @@ def _dagger_query_textproto_impl(ctx):
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],
-        command = "unzip {src_jar} '*.textproto' -d .; zip -R {out} '*.textproto'".format(
+        command = "unzip {src_jar} '*.textproto' -d .; zip {out} '*.textproto'".format(
             src_jar = src_jars[0].path,
             out = ctx.outputs.out.path,
         ),

--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -25,7 +25,7 @@ def _dagger_query_textproto_impl(ctx):
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],
-        command = "unzip {src_jar} '*.textproto' -d .; zip {out} '*.textproto'".format(
+        command = "unzip {src_jar} '*_graph.textproto' -d .; zip {out} '*_graph.textproto'".format(
             src_jar = src_jars[0].path,
             out = ctx.outputs.out.path,
         ),

--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -25,7 +25,7 @@ def _dagger_query_textproto_impl(ctx):
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],
-        command = "touch {out}; unzip {src_jar}; for FILE in *.textproto; do cat $FILE >> {out}; done".format(
+        command = "unzip {src_jar} '*.textproto' -d .; zip -R {out} '*.textproto'".format(
             src_jar = src_jars[0].path,
             out = ctx.outputs.out.path,
         ),
@@ -39,7 +39,7 @@ _dagger_query_textproto = rule(
         ),
     },
     outputs = {
-        "out": "%{name}.textproto",
+        "out": "%{name}.zip",
     },
     implementation = _dagger_query_textproto_impl,
 )

--- a/project/src/com/google/daggerquery/executor/services/SourcesLoader.java
+++ b/project/src/com/google/daggerquery/executor/services/SourcesLoader.java
@@ -20,6 +20,7 @@ import com.google.daggerquery.protobuf.autogen.BindingGraphProto.BindingGraph;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 
 /**
  * A class which loads a binding graph saved with Dagger SPI plugin.
@@ -28,12 +29,13 @@ public class SourcesLoader {
   private static final String PATH_TO_BINDING_GRAPH = "/com/google/daggerquery/binding_graph_data.textproto";
 
   public BindingGraph loadBindingGraph() throws IOException {
-    InputStream inputStream = SourcesLoader.class.getResourceAsStream(PATH_TO_BINDING_GRAPH);
+    try (InputStream inputStream = SourcesLoader.class.getResourceAsStream(PATH_TO_BINDING_GRAPH))  {
+      if (inputStream == null) {
+        throw new FileNotFoundException(String.format("File %s is missing.", PATH_TO_BINDING_GRAPH));
+      }
 
-    if (inputStream == null) {
-      throw new FileNotFoundException(String.format("File %s is missing.", PATH_TO_BINDING_GRAPH));
+      int sizeOfBindingGraph = ByteBuffer.wrap(inputStream.readNBytes(4)).getInt();
+      return BindingGraph.parseFrom(inputStream.readNBytes(sizeOfBindingGraph));
     }
-
-    return BindingGraph.parseFrom(inputStream);
   }
 }

--- a/project/src/com/google/daggerquery/executor/services/SourcesLoader.java
+++ b/project/src/com/google/daggerquery/executor/services/SourcesLoader.java
@@ -20,7 +20,6 @@ import com.google.daggerquery.protobuf.autogen.BindingGraphProto.BindingGraph;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.ByteBuffer;
 
 /**
  * A class which loads a binding graph saved with Dagger SPI plugin.
@@ -29,13 +28,12 @@ public class SourcesLoader {
   private static final String PATH_TO_BINDING_GRAPH = "/com/google/daggerquery/binding_graph_data.textproto";
 
   public BindingGraph loadBindingGraph() throws IOException {
-    try (InputStream inputStream = SourcesLoader.class.getResourceAsStream(PATH_TO_BINDING_GRAPH))  {
-      if (inputStream == null) {
-        throw new FileNotFoundException(String.format("File %s is missing.", PATH_TO_BINDING_GRAPH));
-      }
+    InputStream inputStream = SourcesLoader.class.getResourceAsStream(PATH_TO_BINDING_GRAPH);
 
-      int sizeOfBindingGraph = ByteBuffer.wrap(inputStream.readNBytes(4)).getInt();
-      return BindingGraph.parseFrom(inputStream.readNBytes(sizeOfBindingGraph));
+    if (inputStream == null) {
+      throw new FileNotFoundException(String.format("File %s is missing.", PATH_TO_BINDING_GRAPH));
     }
+
+    return BindingGraph.parseFrom(inputStream);
   }
 }

--- a/project/src/com/google/daggerquery/plugin/QueryPlugin.java
+++ b/project/src/com/google/daggerquery/plugin/QueryPlugin.java
@@ -25,7 +25,6 @@ import javax.annotation.processing.Filer;
 import javax.tools.FileObject;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 
 import static javax.tools.StandardLocation.SOURCE_OUTPUT;
 
@@ -46,10 +45,9 @@ public class QueryPlugin implements BindingGraphPlugin {
         .makeBindingGraphProto(bindingGraph.rootComponentNode(), bindingGraph.network());
 
     try {
-      FileObject sourceFile = filer.createResource(SOURCE_OUTPUT, "", "binding_graph.textproto");
+      String fileName = bindingGraph.rootComponentNode().componentPath().rootComponent().getSimpleName().toString();
+      FileObject sourceFile = filer.createResource(SOURCE_OUTPUT, "", String.format("%s.textproto", fileName));
       try (OutputStream outputStream = sourceFile.openOutputStream()) {
-        byte[] bindingGraphSize = ByteBuffer.allocate(4).putInt(bindingGraphProto.toByteArray().length).array();
-        outputStream.write(bindingGraphSize);
         bindingGraphProto.writeTo(outputStream);
       }
     } catch (IOException e) {

--- a/project/src/com/google/daggerquery/plugin/QueryPlugin.java
+++ b/project/src/com/google/daggerquery/plugin/QueryPlugin.java
@@ -24,6 +24,8 @@ import dagger.spi.DiagnosticReporter;
 import javax.annotation.processing.Filer;
 import javax.tools.FileObject;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 import static javax.tools.StandardLocation.SOURCE_OUTPUT;
 
@@ -45,7 +47,11 @@ public class QueryPlugin implements BindingGraphPlugin {
 
     try {
       FileObject sourceFile = filer.createResource(SOURCE_OUTPUT, "", "binding_graph.textproto");
-      bindingGraphProto.writeTo(sourceFile.openOutputStream());
+      try (OutputStream outputStream = sourceFile.openOutputStream()) {
+        byte[] bindingGraphSize = ByteBuffer.allocate(4).putInt(bindingGraphProto.toByteArray().length).array();
+        outputStream.write(bindingGraphSize);
+        bindingGraphProto.writeTo(outputStream);
+      }
     } catch (IOException e) {
       e.printStackTrace();
     }

--- a/project/src/com/google/daggerquery/plugin/QueryPlugin.java
+++ b/project/src/com/google/daggerquery/plugin/QueryPlugin.java
@@ -46,7 +46,7 @@ public class QueryPlugin implements BindingGraphPlugin {
 
     try {
       String fileName = bindingGraph.rootComponentNode().componentPath().rootComponent().getSimpleName().toString();
-      FileObject sourceFile = filer.createResource(SOURCE_OUTPUT, "", String.format("%s.textproto", fileName));
+      FileObject sourceFile = filer.createResource(SOURCE_OUTPUT, "", String.format("%s_graph.textproto", fileName));
       try (OutputStream outputStream = sourceFile.openOutputStream()) {
         bindingGraphProto.writeTo(outputStream);
       }


### PR DESCRIPTION
Saves all .textproto files into one .zip file

 ### Problem:
 In real applications, there can be multiple binding graphs, because nothing prevents the user from having different components. In this situation method `visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter)` in `QueryPlugin` is calling several times - one call for each graph exactly. With the current solution, only the last graph is saved because it simply fills the resource file only once.

 ### Solution:
 The idea is to save all binding graphs in the .zip file and then extract .textproto files from it in client apps. 

  **Main changes:** 
 * in implementation of `dagger_query_textproto.bzl` changed command - now it unzips all files with .textproto extension and puts them into new zip package;
 * in `QueryPlugin` saves binding graphs into different files which name is constructed via component's name.

 ### Alternatives:
 I thought about making a new proto-model - a wrapper for a list of `BindingGraph` instances. But it's impossible to change the content of resource file which was created on the previous step: [Filer](https://docs.oracle.com/javase/7/docs/api/javax/annotation/processing/Filer.html) class has a method `getResource(...)` **but it allows to open a file for reading, not for writing 😢** 

[Card](https://github.com/googleinterns/dagger-query/projects/1#card-43510033)