### PR TITLE
Supported unzipping archive in a command-line app

### DIFF
--- a/project/src/com/google/daggerquery/executor/BUILD
+++ b/project/src/com/google/daggerquery/executor/BUILD
@@ -23,5 +23,7 @@ java_binary(
     deps = [
         "//src/com/google/daggerquery/executor/models:query_executor_models",
         "//src/com/google/daggerquery/executor/services:query_executor_services",
+        "//src/com/google/daggerquery/protobuf:binding_graph_java_proto",
+        "//third_party/java/guava:guava",
     ],
 )

--- a/project/src/com/google/daggerquery/executor/services/BUILD
+++ b/project/src/com/google/daggerquery/executor/services/BUILD
@@ -22,5 +22,6 @@ java_library(
     deps = [
         "//src/com/google/daggerquery/executor/models:query_executor_models",
         "//src/com/google/daggerquery/protobuf:binding_graph_java_proto",
+        "//third_party/java/guava:guava",
     ]
 )

--- a/project/src/com/google/daggerquery/executor/services/SourcesLoader.java
+++ b/project/src/com/google/daggerquery/executor/services/SourcesLoader.java
@@ -33,7 +33,7 @@ import java.util.zip.ZipFile;
  */
 public class SourcesLoader {
   private static final String PATH_TO_BINDING_GRAPHS = "/com/google/daggerquery/binding_graph_data.zip";
-  private static final String BINDING_GRAPHS_SOURCES = "binding_graphs.bin";
+  private static final String BINDING_GRAPHS_SOURCES = "binding_graphs.tmp";
 
   /**
    * Reads .zip resource file which contains several .textproto files with serialized binding graphs.


### PR DESCRIPTION
Supports unzipping archive with _.textproto files_ in a command-line app 📨

> The second step of supporting multiple graphs in a project. Plugin changes included in #17.

**Main changes:**
 1. Adds `guava` dependency for **QueryExecutor** and **SourcesLoader** as they use data structures and Files class from Guava.
 2. Supports analysis of multiple graphs in **QueryExecutor** by trying to execute a query in each of them.
 3. Supports extracting .zip file in **SourcesLoader** and deserializing binding graphs from all files located in .zip archive.

[Card](https://github.com/googleinterns/dagger-query/projects/1#card-43510033)