### PR TITLE
Adds Javadoc where it was missing

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -61,8 +61,8 @@ public class Query {
    * <p>Checks that passed arguments are correct and not {@code null}. The {@code parameters} argument is
    * correct when its length equals to the value in {@code supportedQueries}.
    *
-   * <p>Throws {@link IllegalArgumentException} if number of parameters is invalid or query's name is invalid.
-   * Throws {@link NullPointerException} if any of arguments are equal to {@code null}.
+   * @throws IllegalArgumentException if number of parameters is invalid or query's name is invalid
+   * @throws NullPointerException if any of arguments are equal to {@code null}
    */
   public Query(String typeName, String... parameters) {
     if (typeName == null || parameters == null) {
@@ -94,6 +94,8 @@ public class Query {
    * The connection between nodes is shown with the construction '->'. For example, one of the possible paths
    * may look like this: "com.google.First -> com.google.Second -> com.google.Third".
    * </ul>
+   *
+   * @throws IllegalArgumentException if specified source node doesn't exist
    */
   public List<String> execute(BindingGraph bindingGraph) {
     switch (name) {
@@ -157,7 +159,7 @@ public class Query {
   }
 
   /**
-   * Traverses a {@link BindingGraph} starting from {@code source} node.
+   * Traverses a {@link BindingGraph} starting from {@code source} node to find all paths between nodes.
    *
    * <p>Puts all processed nodes in a {@code visitedNodes} set to avoid loops. Constructs a {@code path} which is
    * an instance of {@link Path<String>}. At each recursive level this variable contains a correct path in a graph from

--- a/project/src/com/google/daggerquery/plugin/QueryPlugin.java
+++ b/project/src/com/google/daggerquery/plugin/QueryPlugin.java
@@ -38,6 +38,15 @@ public class QueryPlugin implements BindingGraphPlugin {
     this.filer = filer;
   }
 
+  /**
+   * This method is called once for each binding graph presented in the app.
+   *
+   * <p>Converts given {@link BindingGraph} into <a href="https://en.wikipedia.org/wiki/Adjacency_list">adjacency list</a>
+   * and serializes it via <a href="https://developers.google.com/protocol-buffers">protocol buffers library</a>.
+   *
+   * <p>Saves each binding graph into a separate file. The file names are constructed from a simple name of a
+   * root component of a graph and extension .textproto.
+   */
   @Override
   public void visitGraph(BindingGraph bindingGraph, DiagnosticReporter diagnosticReporter) {
     BindingGraphProto.BindingGraph bindingGraphProto = new GraphConverter<BindingGraph.Node, BindingGraph.Edge>()


### PR DESCRIPTION
Improves Javadoc by adding more details

**Main changes:**
 1. Adds Javadoc to public method `visitGraph(...)` in `QueryPlugin`.
 2. Adds `@throws` tags for methods which can throw an exception.
 3. Highlights the sense of `findAllPaths(...)` method.