### PR TITLE
Supported SOMEPATH query 🔫

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -23,6 +23,7 @@ import com.google.daggerquery.protobuf.autogen.DependencyProto.Dependency;
 import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
@@ -141,7 +142,7 @@ public class Query {
           return new ArrayList<>();
         }
 
-        return List.of(path.toString());
+        return Arrays.asList(path.toString());
       }
     }
 

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto;
 import com.google.daggerquery.protobuf.autogen.DependencyProto;
 import org.junit.Test;
@@ -249,12 +250,13 @@ public class QueryTest {
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
 
-    Set<String> possibleOutputs = Set.of(
+    Set<String> possibleOutputs = Sets.newHashSet(
         "com.google.Component -> com.google.Details",
         "com.google.Component -> com.google.Cat -> com.google.Details",
         "com.google.Component -> com.google.CatsFactory -> com.google.Cat -> com.google.Details",
         "com.google.Component -> com.google.Helper -> com.google.CatsFactory -> com.google.Cat -> com.google.Details"
     );
+
 
     assertEquals(1, queryExecutionResult.size());
     assertTrue(possibleOutputs.contains(queryExecutionResult.get(0)));


### PR DESCRIPTION
Supports SOMEPATH query

**Details:**
* _somepath_ implementation is deterministic and will return the same path for the same input
* _somepath_ works faster than _allpaths_ because it stops after it finds any path between `source` and `target` nodes

**Alternatives:**
Query _somepath_ can return the shortest path but in order to find it we will execute `findAllPaths(...)` method and then sort an output - it's quite long and may lead to big delays in a huge graph. The main purpose of _somepath_ is to figure out if there are any paths between nodes at all and to show any of them, so it is preferable to return the first path found by DFS. This approach is consistent with _somepath_ implementation in [bazel query language](https://github.com/bazelbuild/bazel/blob/37f11bfd2dc528fcf61b9162b277c7355e926396/src/main/java/com/google/devtools/build/lib/query2/query/PathLabelVisitor.java#L79).

**Main changes:**
1. Registers new _somepath_ query type in a `Query` class.
2. In `Query` class implements method `findSomePath(...)` which is used in the public method `execute(...)` to support _somepath_ query. This method contains a slightly modified implementation of Depth-first search algorithm.
3. Covered query execution algorithm with tests in `QueryTest`. 

[Card №1](https://github.com/googleinterns/dagger-query/projects/1#card-43792823)
[Card №2](https://github.com/googleinterns/dagger-query/projects/1#card-43792840)