### PR TITLE
Changed command to avoid including files from current directory

### DIFF
--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -25,7 +25,7 @@ def _dagger_query_textproto_impl(ctx):
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],
-        command = "unzip {src_jar} '*_graph.textproto' -d .; zip {out} '*_graph.textproto'".format(
+        command = "unzip {src_jar} '*_graph.textproto' -d graphs; cd graphs; zip -r ../{out} .".format(
             src_jar = src_jars[0].path,
             out = ctx.outputs.out.path,
         ),

--- a/project/src/com/google/daggerquery/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/dagger_query_textproto.bzl
@@ -25,7 +25,7 @@ def _dagger_query_textproto_impl(ctx):
     ctx.actions.run_shell(
         inputs = src_jars,
         outputs = [ctx.outputs.out],
-        command = "unzip {src_jar} '*_graph.textproto' -d graphs; cd graphs; zip -r ../{out} .".format(
+        command = "unzip {src_jar} '*_graph.textproto' -d binding_graphs_tmp; cd binding_graphs_tmp; zip -r ../{out} .; cd ..; rm -r binding_graphs_tmp".format(
             src_jar = src_jars[0].path,
             out = ctx.outputs.out.path,
         ),


### PR DESCRIPTION
Changes command shell by removing using a wildcard in zip command

I realized that it's possible to use wildcards to archive files of **specific extensions only** so `*_graph.textproto` will not work properly. Also with this implementation using flag `-r` is required because without it `zip` command fails to pack everything in current `.` directory. 