### PR TITLE
Supported typos fixer ⚙️

### DIFF
--- a/project/WORKSPACE
+++ b/project/WORKSPACE
@@ -47,3 +47,10 @@ google_common_workspace_rules()
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
+
+http_jar (
+    name = "apache-commons-text",
+    url = "https://repo1.maven.org/maven2/org/apache/commons/commons-text/1.9/commons-text-1.9.jar"
+)

--- a/project/src/com/google/daggerquery/executor/models/BUILD
+++ b/project/src/com/google/daggerquery/executor/models/BUILD
@@ -22,6 +22,7 @@ java_library(
     deps = [
         "//src/com/google/daggerquery/protobuf:binding_graph_java_proto",
         "//src/com/google/daggerquery/protobuf:dependency_java_proto",
-        "//third_party/java/guava:guava"
+        "//third_party/java/guava:guava",
+        "@apache-commons-text//jar"
     ],
 )

--- a/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
+++ b/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
@@ -1,0 +1,21 @@
+package com.google.daggerquery.executor.models;
+
+/**
+ * An exception is thrown to indicate that a binding name contains a typo.
+ *
+ * <p>This exception <b>should</b> be used to report a typo in a binding node name,
+ * which user has provided as a query parameter.
+ */
+public class MisspelledNodeNameException extends RuntimeException {
+
+  /**
+   * Constructs a <code>MisspelledNodeNameException</code> with a detail message
+   * consisting of the given binding name with typo followed by the correct binding name
+   * which presented in a binding graph.
+   */
+  public MisspelledNodeNameException(String nodeNameWithTypo, String correctNodeName) {
+    super(String.format("Binding with name %s contains a typo and not found in a graph. Maybe you meant %s?",
+                        nodeNameWithTypo, correctNodeName));
+  }
+
+}

--- a/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
+++ b/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
@@ -9,7 +9,7 @@ package com.google.daggerquery.executor.models;
 public class MisspelledNodeNameException extends RuntimeException {
 
   /**
-   * Constructs a <code>MisspelledNodeNameException</code> with a detail message
+   * Constructs a <code>MisspelledNodeNameException</code> with a detailed message
    * consisting of the given binding name with typo followed by the correct binding name
    * which presented in a binding graph.
    */

--- a/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
+++ b/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
@@ -1,5 +1,7 @@
 package com.google.daggerquery.executor.models;
 
+import java.util.List;
+
 /**
  * An exception is thrown to indicate that a binding name contains a typo.
  *
@@ -10,12 +12,12 @@ public class MisspelledNodeNameException extends RuntimeException {
 
   /**
    * Constructs a <code>MisspelledNodeNameException</code> with a detailed message
-   * consisting of the given binding name with typo followed by the correct binding name
-   * which presented in a binding graph.
+   * consisting of the provided binding name, followed by similarly named bindings
+   * that exist in our binding graph.
    */
-  public MisspelledNodeNameException(String nodeNameWithTypo, String correctNodeName) {
+  public MisspelledNodeNameException(String nodeNameWithTypo, List<String> correctNodesName) {
     super(String.format("Binding with name %s contains a typo and not found in a graph. Maybe you meant %s?",
-                        nodeNameWithTypo, correctNodeName));
+                        nodeNameWithTypo, String.join(" or ", correctNodesName)));
   }
 
 }

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -306,15 +306,10 @@ public class Query {
    */
   private List<String> findNodesWithClosestName(String originalNode, Set<String> allNodes) {
     List<String> closestNodes = new ArrayList<>();
-    int bestDistance = Integer.MAX_VALUE;
 
     for (String node: allNodes) {
       int distance = levenshteinDistanceCalculator.apply(originalNode, node);
-      if (distance <= MAX_NUMBER_OF_MISPLACED_LETTERS && distance < bestDistance) {
-        closestNodes.clear();
-        closestNodes.add(node);
-        bestDistance = distance;
-      } else if (distance == bestDistance) {
+      if (distance <= MAX_NUMBER_OF_MISPLACED_LETTERS) {
         closestNodes.add(node);
       }
     }

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -267,7 +267,7 @@ public class Query {
   }
 
   /**
-   * Checks if the passed {@code node} is on the {@link BindingGraph} or if the user misspelled the node's name.
+   * Checks if the passed {@code node} is in the {@link BindingGraph} or if the user misspelled the node's name.
    *
    * <p>If the passed node is correct, does nothing.
    * Otherwise, it throws an exception, the type of which depends on the node's name.

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -20,7 +20,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto.BindingGraph;
 import com.google.daggerquery.protobuf.autogen.DependencyProto.Dependency;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,6 +28,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.commons.text.similarity.LevenshteinDistance;
+import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import static java.util.stream.Collectors.toList;
 
@@ -45,6 +46,13 @@ public class Query {
   private final static String DEPS_QUERY_NAME = "deps";
   private final static String ALLPATHS_QUERY_NAME = "allpaths";
   private final static String SOMEPATH_QUERY_NAME = "somepath";
+
+  private final static int MAX_NUMBER_OF_MISPLACED_LETTERS = 3;
+
+  /**
+   * An algorithm for measuring distances between node names in a binding graph to detect typos.
+   */
+  private final static LevenshteinDistance levenshteinDistanceCalculator = new LevenshteinDistance();
 
   /**
    * The key is the name of supported query and the value is the number of parameters,
@@ -99,6 +107,9 @@ public class Query {
    * may look like this: "com.google.First -> com.google.Second -> com.google.Third".
    * </ul>
    *
+   * @throws MisspelledNodeNameException if the specified source node contains a typo
+   * and can be corrected in no more than three steps
+   *
    * @throws IllegalArgumentException if specified source node doesn't exist
    */
   public List<String> execute(BindingGraph bindingGraph) {
@@ -106,9 +117,7 @@ public class Query {
       case DEPS_QUERY_NAME: {
         String source = parameters[0];
 
-        if (!bindingGraph.getAdjacencyListMap().containsKey(source)) {
-          throw new IllegalArgumentException(String.format("Specified source node %s doesn't exist.", source));
-        }
+        checkNodeForCorrectness(source, bindingGraph);
 
         return bindingGraph.getAdjacencyListMap().get(source).getDependencyList()
             .stream().map(Dependency::getTarget).sorted().collect(toList());
@@ -116,9 +125,7 @@ public class Query {
       case ALLPATHS_QUERY_NAME: {
         String source = parameters[0];
 
-        if (!bindingGraph.getAdjacencyListMap().containsKey(source)) {
-          throw new IllegalArgumentException(String.format("Specified source node %s doesn't exist.", source));
-        }
+        checkNodeForCorrectness(source, bindingGraph);
 
         String target = parameters[1];
         Set<String> visitedNodes = new HashSet<>();
@@ -131,9 +138,7 @@ public class Query {
       case SOMEPATH_QUERY_NAME: {
         String source = parameters[0];
 
-        if (!bindingGraph.getAdjacencyListMap().containsKey(source)) {
-          throw new IllegalArgumentException(String.format("Specified source node %s doesn't exist.", source));
-        }
+        checkNodeForCorrectness(source, bindingGraph);
 
         String target = parameters[1];
         Set<String> visitedNodes = new HashSet<>();
@@ -259,5 +264,57 @@ public class Query {
     path.removeLast();
 
     return false;
+  }
+
+  /**
+   * Checks if the passed {@code node} is on the {@link BindingGraph} or if the user misspelled the node's name.
+   *
+   * <p>If the passed node is correct, does nothing.
+   * Otherwise, it throws an exception, the type of which depends on the node's name.
+   *
+   * @throws MisspelledNodeNameException if specified source node contains a typo
+   * and can be corrected in no more than three steps
+   *
+   * @throws IllegalArgumentException if specified source node doesn't exist
+   */
+  private void checkNodeForCorrectness(String node, BindingGraph bindingGraph) {
+    if (bindingGraph.getAdjacencyListMap().containsKey(node)) {
+      return;
+    }
+
+    // The specified node could not be found on the graph, we need to check for typos.
+    String closestNode = findNodeWithClosestName(node, bindingGraph.getAdjacencyListMap().keySet());
+    if (closestNode == null) {
+      throw new IllegalArgumentException(String.format("Specified source node %s doesn't exist.", node));
+    } else {
+      throw new MisspelledNodeNameException(/*nodeNameWithTypo =*/ node, /*correctNodeName =*/ closestNode);
+    }
+  }
+
+  /**
+   * Finds the closest node in a given {@link Set<String>} to the {@code originalNode}.
+   *
+   * <p>For measuring a distance uses <a href = "https://en.wikipedia.org/wiki/Levenshtein_distance">Levenshtein distance metric</a>.
+   * It simply calculates the number of changes required to be made to get one sequence from another,
+   * where each change is a single character modification (deletion, insertion or substitution).
+   *
+   * <p>TA node can be considered a neighbor only if the distance between it and the given {@code originalNode}
+   * is less than or equal to {@code MAX_NUMBER_OF_MISPLACED_LETTERS}.
+   *
+   * <p>If a node with a similar name is not found, returns {@code null}.
+   */
+  private String findNodeWithClosestName(String originalNode, Set<String> allNodes) {
+    String closestNode = null;
+    int bestDistance = Integer.MAX_VALUE;
+
+    for (String node: allNodes) {
+      int distance = levenshteinDistanceCalculator.apply(originalNode, node);
+      if (distance <= MAX_NUMBER_OF_MISPLACED_LETTERS && distance < bestDistance) {
+        closestNode = node;
+        bestDistance = distance;
+      }
+    }
+
+    return closestNode;
   }
 }

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -126,7 +126,7 @@ public class QueryTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testExecutingDepsQuery_WithFourTyposInNodeName_ThrowsIllegalArgumentException() {
+  public void testExecutingDepsQuery_WithTooManyTyposInNodeName_ThrowsIllegalArgumentException() {
     String[] parameters = {"com.google.CatsFactory...."};
     Query query = new Query("deps", parameters);
 
@@ -241,7 +241,7 @@ public class QueryTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testExecutingAllPathsQuery_WithFourTyposInNodeName_ThrowsIllegalArgumentException() {
+  public void testExecutingAllPathsQuery_WithTooManyTyposInNodeName_ThrowsIllegalArgumentException() {
     String[] parameters = {"com.google.com.CatsFactory", "com.google.Details"};
     Query query = new Query("allpaths", parameters);
 
@@ -357,7 +357,7 @@ public class QueryTest {
   }
 
   @Test(expected = IllegalArgumentException.class)
-  public void testExecutingSomePathQuery_WithFourTyposInNodeName_ThrowsIllegalArgumentException() {
+  public void testExecutingSomePathQuery_WithTooManyTyposInNodeName_ThrowsIllegalArgumentException() {
     String[] parameters = {"com.google.com.CatsFactory", "com.google.Details"};
     Query query = new Query("somepath", parameters);
 

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -19,12 +19,12 @@ package com.google.daggerquery.executor.models;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto;
 import com.google.daggerquery.protobuf.autogen.DependencyProto;
 import org.junit.Test;
-
 import java.util.List;
 import java.util.Set;
 
@@ -109,6 +109,28 @@ public class QueryTest {
     Query query = new Query("deps", parameters);
 
     query.execute(null);
+  }
+
+  @Test
+  public void testExecutingDepsQuery_WithOneTypoInNodeName_ThrowsMisspelledNodeNameException() {
+    try {
+      String[] parameters = {"com.google.CatsFactoryy"};
+      Query query = new Query("deps", parameters);
+
+      List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
+      fail();
+    } catch (MisspelledNodeNameException e) {
+      // We do not care too much about the rest of the message, but it should contain a correct node name.
+      assertTrue(e.getMessage().contains("com.google.CatsFactory"));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecutingDepsQuery_WithFourTyposInNodeName_ThrowsIllegalArgumentException() {
+    String[] parameters = {"com.google.CatsFactory...."};
+    Query query = new Query("deps", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
   }
 
   // Tests for `ALLPATHS` query
@@ -204,6 +226,28 @@ public class QueryTest {
     query.execute(null);
   }
 
+  @Test
+  public void testExecutingAllPathsQuery_WithThreeTyposInNodeName_ThrowsMisspelledNodeNameException() {
+    try {
+      String[] parameters = {"com.google.CatsFactories", "com.google.Details"};
+      Query query = new Query("allpaths", parameters);
+
+      List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
+      fail();
+    } catch (MisspelledNodeNameException e) {
+      // We do not care too much about the rest of the message, but it should contain a correct node name.
+      assertTrue(e.getMessage().contains("com.google.CatsFactory"));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecutingAllPathsQuery_WithFourTyposInNodeName_ThrowsIllegalArgumentException() {
+    String[] parameters = {"com.google.com.CatsFactory", "com.google.Details"};
+    Query query = new Query("allpaths", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
+  }
+
   // Tests for `SOMEPATH` query
 
   @Test(expected = IllegalArgumentException.class)
@@ -296,6 +340,28 @@ public class QueryTest {
     Query query = new Query("somepath", parameters);
 
     query.execute(null);
+  }
+
+  @Test
+  public void testExecutingSomePathQuery_WithTwoTyposInNodeName_ThrowsMisspelledNodeNameException() {
+    try {
+      String[] parameters = {"c.google.CatsFactory", "com.google.Details"};
+      Query query = new Query("somepath", parameters);
+
+      List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
+      fail();
+    } catch (MisspelledNodeNameException e) {
+      // We do not care too much about the rest of the message, but it should contain a correct node name.
+      assertTrue(e.getMessage().contains("com.google.CatsFactory"));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecutingSomePathQuery_WithFourTyposInNodeName_ThrowsIllegalArgumentException() {
+    String[] parameters = {"com.google.com.CatsFactory", "com.google.Details"};
+    Query query = new Query("somepath", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
   }
 
   /*


### PR DESCRIPTION
Adds an additional check for typos in the name of the binding node if the node was not found in the graph.

**Problem:** usually binding node names quite long and it may be difficult to write them correctly from scratch. This PR adds special check for typos in a name if the node was not found as a key in an adjacency list. 

> `deps com.goooogle.Beach`
**Result:** `Execution failed. Reason: Binding with name deps com.goooogle.Beach contains a typo and not found in a graph. Maybe you meant deps com.google.Beach?`

For measuring distances between strings uses [Levenshtein Distance](https://en.wikipedia.org/wiki/Levenshtein_distance) metric from [org.apache.commons.text.similarity](https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/similarity/LevenshteinDistance.html). The name is considered to contain a typo if the distance to the existing node is no more than 3.

**Main changes:**
 * In `WORKSPACE` file loads Apache Commons Text library jar.
 * This dependency is used in a `//src/com/google/daggerquery/executor/models/BUILD` file.
 * Implemented an unchecked `MisspelledNodeNameException` exception to determine when a typo was encountered while executing a request.
 * Added tests for each type of query, checking for situations when the node name contains a typo and when the number of corrections is too large to consider the names similar.