### PR TITLE
Simplifies Java code for j2cl compatibility

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
+++ b/project/src/com/google/daggerquery/executor/models/MisspelledNodeNameException.java
@@ -16,8 +16,11 @@ public class MisspelledNodeNameException extends RuntimeException {
    * that exist in our binding graph.
    */
   public MisspelledNodeNameException(String nodeNameWithTypo, List<String> correctNodesName) {
-    super(String.format("Binding with name %s contains a typo and not found in a graph. Maybe you meant %s?",
-                        nodeNameWithTypo, String.join(" or ", correctNodesName)));
+    super("Binding with name "
+            + nodeNameWithTypo
+            + " contains a typo and not found in a graph. Maybe you meant "
+            + String.join(" or ", correctNodesName)
+            + "?");
   }
 
 }

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -20,13 +20,16 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-import com.google.daggerquery.protobuf.autogen.BindingGraphProto;
-import com.google.daggerquery.protobuf.autogen.DependencyProto;
-import org.junit.Test;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import org.junit.Test;
 
 public class QueryTest {
 
@@ -370,28 +373,12 @@ public class QueryTest {
    * com.google.Component --> com.google.CatsFactory --> com.google.Cat
    * com.google.Component --> com.google.Helper
    */
-  private BindingGraphProto.BindingGraph makeSimpleBindingGraph() {
-    DependencyProto.Dependency factoryNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.CatsFactory").build();
-    DependencyProto.Dependency catNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.Cat").build();
-    DependencyProto.Dependency helperNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.Helper").build();
-
-    BindingGraphProto.BindingGraph.ListWithDependencies componentNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .addDependency(factoryNode)
-        .addDependency(helperNode)
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies catsFactoryNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .addDependency(catNode)
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies catNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies helperNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .build();
-
-    return BindingGraphProto.BindingGraph.newBuilder()
-        .putAdjacencyList("com.google.Component", componentNodeDeps)
-        .putAdjacencyList("com.google.CatsFactory", catsFactoryNodeDeps)
-        .putAdjacencyList("com.google.Cat", catNodeDeps)
-        .putAdjacencyList("com.google.Helper", helperNodeDeps)
+  private Map<String, List<String>> makeSimpleBindingGraph() {
+    return new ImmutableMap.Builder<String, List<String>>()
+        .put("com.google.Component", Arrays.asList("com.google.CatsFactory", "com.google.Helper"))
+        .put("com.google.CatsFactory", Arrays.asList("com.google.Cat"))
+        .put("com.google.Cat", new ArrayList<>())
+        .put("com.google.Helper", new ArrayList<>())
         .build();
   }
 
@@ -403,36 +390,13 @@ public class QueryTest {
    * com.google.Component --> com.google.Cat --> com.google.Details
    * com.google.Component --> com.google.Details
    */
-  private BindingGraphProto.BindingGraph makeBindingGraph_WithMultiplePathsBetweenTwoNodes() {
-    DependencyProto.Dependency factoryNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.CatsFactory").build();
-    DependencyProto.Dependency catNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.Cat").build();
-    DependencyProto.Dependency helperNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.Helper").build();
-    DependencyProto.Dependency detailsNode = DependencyProto.Dependency.newBuilder().setTarget("com.google.Details").build();
-
-    BindingGraphProto.BindingGraph.ListWithDependencies componentNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .addDependency(factoryNode)
-        .addDependency(helperNode)
-        .addDependency(catNode)
-        .addDependency(detailsNode)
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies catsFactoryNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .addDependency(catNode)
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies helperNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .addDependency(factoryNode)
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies catNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .addDependency(detailsNode)
-        .build();
-    BindingGraphProto.BindingGraph.ListWithDependencies detailsNodeDeps = BindingGraphProto.BindingGraph.ListWithDependencies.newBuilder()
-        .build();
-
-    return BindingGraphProto.BindingGraph.newBuilder()
-        .putAdjacencyList("com.google.Component", componentNodeDeps)
-        .putAdjacencyList("com.google.CatsFactory", catsFactoryNodeDeps)
-        .putAdjacencyList("com.google.Helper", helperNodeDeps)
-        .putAdjacencyList("com.google.Cat", catNodeDeps)
-        .putAdjacencyList("com.google.Details", detailsNodeDeps)
+  private Map<String, List<String>> makeBindingGraph_WithMultiplePathsBetweenTwoNodes() {
+    return new ImmutableMap.Builder<String, List<String>>()
+        .put("com.google.Component", Arrays.asList("com.google.CatsFactory", "com.google.Helper", "com.google.Cat", "com.google.Details"))
+        .put("com.google.CatsFactory", Arrays.asList("com.google.Cat"))
+        .put("com.google.Helper", Arrays.asList("com.google.CatsFactory"))
+        .put("com.google.Cat", Arrays.asList("com.google.Details"))
+        .put("com.google.Details", new ArrayList<>())
         .build();
   }
 }


### PR DESCRIPTION
Simplifies Java code for j2cl compatibility.

**We decided to use `j2cl` to reuse queries execution logic.**

**Problems and solutions:**
* `String.format(...)` method [isn't supported by `j2cl`. ](https://gwt.googlesource.com/gwt/+/master/user/super/com/google/gwt/emul/java/lang/String.java#73) All uses of this method have been replaced with simple string concatenation.
* `Apache Commons Text` isn't supported by `j2cl`. Implemented a method which calculates the distance between two strings using dynamic programming [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance) algorithm.
* `j2cl protobuf` isn't fully supported. I have contacted `j2cl` team, and they told me that `j2cl_proto` works in Google3, but it's not ready yet to work with Bazel. I have tried to use `new_j2cl_proto_library` but it complains about dependencies ([full output](https://gist.github.com/margaritiko/98c33d7d81d7c30abaf486f728c5cfd8) for [BUILD file](https://gist.github.com/margaritiko/21325e7d75d866fb1cb806b305f2df9f)) what could be caused by a bug in j2cl protobuf implementation. The solution is to convert `BindingGraph` proto model to a simple adjacency list representation `Map<String, List<String>>`. This approach also greatly simplifies the creation of fake graphs in tests and improves the readability of the query implementation (albeit with additional memory costs).
* `NotImplementedException` has been replaced with `UnsupportedOperationException`.
