### PR TITLE
Split the main method in QueryExecutor into two different 🧩

### DIFF
--- a/project/src/com/google/daggerquery/executor/QueryExecutor.java
+++ b/project/src/com/google/daggerquery/executor/QueryExecutor.java
@@ -56,7 +56,7 @@ public class QueryExecutor {
    * @throws IOException when files with binding graphs cannot be found
    * @return an instance of {@link ImmutableList} which contains query's results
    */
-  public static ImmutableList execute(String[] args) throws IOException {
+  public static ImmutableList<String> execute(String[] args) throws IOException {
     if (args.length == 0) {
       throw new IllegalArgumentException("You did not specify the request and its parameters.");
     }
@@ -64,7 +64,7 @@ public class QueryExecutor {
     Query query = new Query(args[0], Arrays.copyOfRange(args, 1, args.length));
     List<BindingGraph> bindingGraphs = new SourcesLoader().loadBindingGraphs();
 
-    ImmutableList.Builder resultBuilder = new ImmutableList.Builder();
+    ImmutableList.Builder<String> resultBuilder = new ImmutableList.Builder();
 
     // We assume that we successfully executed a query only if in at least one graph it was executed without fail.
     MisspelledNodeNameException lastMisspelledNodeNameException = null;
@@ -79,7 +79,7 @@ public class QueryExecutor {
       }
     }
 
-    ImmutableList resultList = resultBuilder.build();
+    ImmutableList<String> resultList = resultBuilder.build();
     if (resultList.isEmpty()) {
       if (lastMisspelledNodeNameException != null) {
         throw new IllegalArgumentException(lastMisspelledNodeNameException.getMessage());


### PR DESCRIPTION
Refactor `QueryExecutor` class and split the `main` method into two different.

To reuse this logic, which takes an array with the name of the request and its parameters, let's create a separate method.

**Main changes:**
* method `main(String[] args)` is responsible for taking command line arguments, requesting the result of the query from another method, and printing it to the console
* method `execute(String[] args)` executes the query and puts the results into a list.