### PR TITLE
Added bazel rule for creating a server

### DIFF
--- a/project/src/com/google/daggerquery/plugin/dagger_query_textproto.bzl
+++ b/project/src/com/google/daggerquery/plugin/dagger_query_textproto.bzl
@@ -39,7 +39,7 @@ _dagger_query_textproto = rule(
         ),
     },
     outputs = {
-        "out": "%{name}.zip",
+        "out": "binding_graph_data.zip",
     },
     implementation = _dagger_query_textproto_impl,
 )

--- a/project/src/com/google/daggerquery/server/dagger_query_server.bzl
+++ b/project/src/com/google/daggerquery/server/dagger_query_server.bzl
@@ -16,8 +16,10 @@ load("@rules_java//java:defs.bzl", "java_binary")
 load("//src/com/google/daggerquery/plugin:dagger_query_textproto.bzl", "dagger_query_textproto")
 
 def dagger_query_server(name, dagger_app_target):
+   binding_graph_data_name = name + "_binding_graph_data"
+
    dagger_query_textproto(
-       name = "binding_graph_data",
+       name = binding_graph_data_name,
        dagger_app_target = dagger_app_target
    )
 
@@ -25,5 +27,5 @@ def dagger_query_server(name, dagger_app_target):
      name = name,
      main_class = "com.google.daggerquery.server.Server",
      runtime_deps = ["//src/com/google/daggerquery/server:server"],
-     resources = [":binding_graph_data"],
+     resources = [":" + binding_graph_data_name],
    )

--- a/project/src/com/google/daggerquery/server/dagger_query_server.bzl
+++ b/project/src/com/google/daggerquery/server/dagger_query_server.bzl
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@rules_java//java:defs.bzl", "java_binary")
+load("//src/com/google/daggerquery/plugin:dagger_query_textproto.bzl", "dagger_query_textproto")
+
+def dagger_query_server(name, dagger_app_target):
+   dagger_query_textproto(
+       name = "binding_graph_data",
+       dagger_app_target = dagger_app_target
+   )
+
+   java_binary(
+     name = name,
+     main_class = "com.google.daggerquery.server.Server",
+     runtime_deps = ["//src/com/google/daggerquery/server:server"],
+     resources = [":binding_graph_data"],
+   )


### PR DESCRIPTION
Add bazel rule for creating a server and connecting target with resources to it.

**How to use?**
```
dagger_query_server(
    name = "java_server",
    dagger_app_target = "//src/com/google/daggerquery/example:example" # Name of the main app target
)
```

[Card](https://github.com/googleinterns/dagger-query/projects/2#card-44227014)