### PR TITLE
Add an example target

### DIFF
--- a/project/src/com/google/daggerquery/example/BUILD
+++ b/project/src/com/google/daggerquery/example/BUILD
@@ -12,19 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_plugin")
-load("//src/com/google/daggerquery/server:dagger_query_server.bzl", "dagger_query_server")
+load("@rules_java//java:defs.bzl", "java_binary")
+load("@dagger//:workspace_defs.bzl", "dagger_rules")
 
+dagger_rules();
 package(default_visibility = ["//visibility:public"])
 
-java_plugin(
-    name = "dagger_query_plugin",
+java_binary(
+    name = "beach_example",
+    srcs = glob(["*.java"]),
+    main_class = "com.google.daggerquery.example.Main",
     deps = [
-        "//src/com/google/daggerquery/plugin:plugin_sources",
-    ]
-)
-
-dagger_query_server(
-    name = "example_java_server",
-    dagger_app_target = "//src/com/google/daggerquery/example:beach_example"
+        ":dagger",
+        "//src/com/google/daggerquery/example/models:example_models",
+        "//src/com/google/daggerquery/example/modules:example_modules",
+        "//src/com/google/daggerquery:dagger_query_plugin"
+    ],
+    plugins = ["//src/com/google/daggerquery:dagger_query_plugin"]
 )

--- a/project/src/com/google/daggerquery/example/BeachComponent.java
+++ b/project/src/com/google/daggerquery/example/BeachComponent.java
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example;
+
+import com.google.daggerquery.example.models.Tourist;
+import com.google.daggerquery.example.models.Beach;
+import com.google.daggerquery.example.modules.PeopleModule;
+import dagger.Component;
+import dagger.Module;
+import dagger.Subcomponent;
+
+@Subcomponent
+interface TouristsComponent {
+  Tourist getTourist();
+
+  @Subcomponent.Builder
+  interface Builder {
+    TouristsComponent build();
+  }
+}
+
+@Module(subcomponents = TouristsComponent.class)
+class TouristsModule {
+}
+
+@Component(modules = {PeopleModule.class, TouristsModule.class})
+public interface BeachComponent {
+  Beach getBeach();
+}

--- a/project/src/com/google/daggerquery/example/HotelComponent.java
+++ b/project/src/com/google/daggerquery/example/HotelComponent.java
@@ -1,0 +1,27 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example;
+
+import com.google.daggerquery.example.models.Hotel;
+import com.google.daggerquery.example.modules.AccommodationModule;
+import com.google.daggerquery.example.modules.PeopleModule;
+import dagger.Component;
+
+@Component(modules = {PeopleModule.class, TouristsModule.class, AccommodationModule.class})
+public interface HotelComponent {
+  Hotel getHotel();
+}

--- a/project/src/com/google/daggerquery/example/Main.java
+++ b/project/src/com/google/daggerquery/example/Main.java
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example;
+
+public class Main {
+  public static void main(String[] args) {
+    BeachComponent beachComponent = DaggerBeachComponent.create();
+    System.out.println(beachComponent.getBeach());
+
+    ModelsComponent modelsComponent = DaggerModelsComponent.create();
+    System.out.println(modelsComponent.getTourist());
+
+    HotelComponent hotelComponent = DaggerHotelComponent.create();
+    System.out.println(hotelComponent.getHotel());
+  }
+}

--- a/project/src/com/google/daggerquery/example/ModelsComponent.java
+++ b/project/src/com/google/daggerquery/example/ModelsComponent.java
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example;
+
+import com.google.daggerquery.example.models.Lifeguard;
+import com.google.daggerquery.example.models.Manager;
+import com.google.daggerquery.example.models.Tourist;
+import dagger.Component;
+
+@Component
+public interface ModelsComponent {
+  Tourist getTourist();
+
+  Lifeguard getLifeguard();
+
+  Manager getManager();
+}

--- a/project/src/com/google/daggerquery/example/models/Apartment.java
+++ b/project/src/com/google/daggerquery/example/models/Apartment.java
@@ -19,22 +19,18 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class Apartment {
-  @Inject
-  Bed bed;
+  private final Bed bed;
+  private final MiniBar miniBar;
+  private final TV tv;
+  private final Phone phone;
+  private final Tourist tourist;
 
   @Inject
-  MiniBar miniBar;
-
-  @Inject
-  TV tv;
-
-  @Inject
-  Phone phone;
-
-  @Inject
-  Tourist tourist;
-
-  @Inject
-  Apartment() {
+  Apartment(Bed bed, MiniBar miniBar, TV tv, Phone phone, Tourist tourist) {
+    this.bed = bed;
+    this.miniBar = miniBar;
+    this.tv = tv;
+    this.phone = phone;
+    this.tourist = tourist;
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Apartment.java
+++ b/project/src/com/google/daggerquery/example/models/Apartment.java
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Apartment {
+  @Inject
+  Bed bed;
+
+  @Inject
+  MiniBar miniBar;
+
+  @Inject
+  TV tv;
+
+  @Inject
+  Phone phone;
+
+  @Inject
+  Tourist tourist;
+
+  @Inject
+  Apartment() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/BUILD
+++ b/project/src/com/google/daggerquery/example/models/BUILD
@@ -12,19 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_plugin")
-load("//src/com/google/daggerquery/server:dagger_query_server.bzl", "dagger_query_server")
+load("@rules_java//java:defs.bzl", "java_library")
+load("@dagger//:workspace_defs.bzl", "dagger_rules")
 
+dagger_rules()
 package(default_visibility = ["//visibility:public"])
 
-java_plugin(
-    name = "dagger_query_plugin",
+java_library(
+    name = "example_models",
+    srcs = glob(["*.java"]),
     deps = [
-        "//src/com/google/daggerquery/plugin:plugin_sources",
-    ]
-)
-
-dagger_query_server(
-    name = "example_java_server",
-    dagger_app_target = "//src/com/google/daggerquery/example:beach_example"
+        ":dagger",
+    ],
 )

--- a/project/src/com/google/daggerquery/example/models/Beach.java
+++ b/project/src/com/google/daggerquery/example/models/Beach.java
@@ -20,10 +20,9 @@ import javax.inject.Inject;
 import java.util.Set;
 
 public class Beach {
-
-  private Set<Tourist> tourists;
-  private Set<Staff> lifeguards;
-  private IceCreamShop iceCreamShop;
+  private final Set<Tourist> tourists;
+  private final Set<Staff> lifeguards;
+  private final IceCreamShop iceCreamShop;
 
   @Inject
   Beach(Set<Tourist> tourists, Set<Staff> lifeguards, IceCreamShop iceCreamShop) {

--- a/project/src/com/google/daggerquery/example/models/Beach.java
+++ b/project/src/com/google/daggerquery/example/models/Beach.java
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+import java.util.Set;
+
+public class Beach {
+
+  private Set<Tourist> tourists;
+  private Set<Staff> lifeguards;
+  private IceCreamShop iceCreamShop;
+
+  @Inject
+  Beach(Set<Tourist> tourists, Set<Staff> lifeguards, IceCreamShop iceCreamShop) {
+    this.iceCreamShop = iceCreamShop;
+    this.tourists = tourists;
+    this.lifeguards = lifeguards;
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Bed.java
+++ b/project/src/com/google/daggerquery/example/models/Bed.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class Bed {
   @Inject
-  public Bed() {
+  Bed() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Bed.java
+++ b/project/src/com/google/daggerquery/example/models/Bed.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Bed {
+  @Inject
+  public Bed() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/CocaCola.java
+++ b/project/src/com/google/daggerquery/example/models/CocaCola.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class CocaCola {
   @Inject
-  public CocaCola() {
+  CocaCola() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/CocaCola.java
+++ b/project/src/com/google/daggerquery/example/models/CocaCola.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class CocaCola {
+  @Inject
+  public CocaCola() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Fanta.java
+++ b/project/src/com/google/daggerquery/example/models/Fanta.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Fanta {
+  @Inject
+  public Fanta() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Fanta.java
+++ b/project/src/com/google/daggerquery/example/models/Fanta.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class Fanta {
   @Inject
-  public Fanta() {
+  Fanta() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Hotel.java
+++ b/project/src/com/google/daggerquery/example/models/Hotel.java
@@ -22,10 +22,10 @@ import java.util.Map;
 import java.util.Set;
 
 public class Hotel {
-  private Set<Apartment> apartments;
-  private Map<Villa, Integer> villas;
-  private List<Staff> managers;
-  private Pool pool;
+  private final Set<Apartment> apartments;
+  private final Map<Villa, Integer> villas;
+  private final List<Staff> managers;
+  private final Pool pool;
 
   @Inject
   Hotel(Set<Apartment> apartments, Map<Villa, Integer> villas, List<Staff> managers, Pool pool) {

--- a/project/src/com/google/daggerquery/example/models/Hotel.java
+++ b/project/src/com/google/daggerquery/example/models/Hotel.java
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class Hotel {
+  private Set<Apartment> apartments;
+  private Map<Villa, Integer> villas;
+  private List<Staff> managers;
+  private Pool pool;
+
+  @Inject
+  Hotel(Set<Apartment> apartments, Map<Villa, Integer> villas, List<Staff> managers, Pool pool) {
+    this.apartments = apartments;
+    this.villas = villas;
+    this.managers = managers;
+    this.pool = pool;
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/IceCreamShop.java
+++ b/project/src/com/google/daggerquery/example/models/IceCreamShop.java
@@ -1,0 +1,30 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+import java.util.Random;
+
+public class IceCreamShop {
+
+  private int numberOfIceCream;
+
+  @Inject
+  IceCreamShop() {
+    numberOfIceCream = Math.abs((new Random().nextInt()) % 100);
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/IceCreamShop.java
+++ b/project/src/com/google/daggerquery/example/models/IceCreamShop.java
@@ -20,8 +20,7 @@ import javax.inject.Inject;
 import java.util.Random;
 
 public class IceCreamShop {
-
-  private int numberOfIceCream;
+  private final int numberOfIceCream;
 
   @Inject
   IceCreamShop() {

--- a/project/src/com/google/daggerquery/example/models/InflatableDonut.java
+++ b/project/src/com/google/daggerquery/example/models/InflatableDonut.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class InflatableDonut {
   @Inject
-  public InflatableDonut() {
+  InflatableDonut() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/InflatableDonut.java
+++ b/project/src/com/google/daggerquery/example/models/InflatableDonut.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class InflatableDonut {
+  @Inject
+  public InflatableDonut() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/InflatableFlamingo.java
+++ b/project/src/com/google/daggerquery/example/models/InflatableFlamingo.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class InflatableFlamingo {
+  @Inject
+  public InflatableFlamingo() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/InflatableFlamingo.java
+++ b/project/src/com/google/daggerquery/example/models/InflatableFlamingo.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class InflatableFlamingo {
   @Inject
-  public InflatableFlamingo() {
+  InflatableFlamingo() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/InflatableUnicorn.java
+++ b/project/src/com/google/daggerquery/example/models/InflatableUnicorn.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class InflatableUnicorn {
   @Inject
-  public InflatableUnicorn() {
+  InflatableUnicorn() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/InflatableUnicorn.java
+++ b/project/src/com/google/daggerquery/example/models/InflatableUnicorn.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class InflatableUnicorn {
+  @Inject
+  public InflatableUnicorn() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/LifeVest.java
+++ b/project/src/com/google/daggerquery/example/models/LifeVest.java
@@ -23,7 +23,7 @@ public class LifeVest {
   private String surfaceColor;
 
   @Inject
-  public LifeVest() {
+  LifeVest() {
     switch (Math.abs((new Random().nextInt()) % 5)) {
       case 0:
         surfaceColor = "red";

--- a/project/src/com/google/daggerquery/example/models/LifeVest.java
+++ b/project/src/com/google/daggerquery/example/models/LifeVest.java
@@ -1,0 +1,45 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+import java.util.Random;
+
+public class LifeVest {
+  private String surfaceColor;
+
+  @Inject
+  public LifeVest() {
+    switch (Math.abs((new Random().nextInt()) % 5)) {
+      case 0:
+        surfaceColor = "red";
+        break;
+      case 1:
+        surfaceColor = "yellow";
+        break;
+      case 2:
+        surfaceColor = "blue";
+        break;
+      case 3:
+        surfaceColor = "green";
+        break;
+      case 4:
+        surfaceColor = "pink";
+        break;
+    }
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Lifeguard.java
+++ b/project/src/com/google/daggerquery/example/models/Lifeguard.java
@@ -19,11 +19,11 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class Lifeguard implements Staff {
-  @Inject
-  LifeVest lifeVest;
+  private final LifeVest lifeVest;
 
   @Inject
-  public Lifeguard() {
+  Lifeguard(LifeVest lifeVest) {
+    this.lifeVest = lifeVest;
   }
 
   @Override

--- a/project/src/com/google/daggerquery/example/models/Lifeguard.java
+++ b/project/src/com/google/daggerquery/example/models/Lifeguard.java
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Lifeguard implements Staff {
+  @Inject
+  LifeVest lifeVest;
+
+  @Inject
+  public Lifeguard() {
+  }
+
+  @Override
+  public void help() {
+    System.out.println("Lifeguard has helped a tourist to escape big waves 🌊.");
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Manager.java
+++ b/project/src/com/google/daggerquery/example/models/Manager.java
@@ -19,11 +19,11 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class Manager implements Staff {
-  @Inject
-  Phone phone;
+  private final Phone phone;
 
   @Inject
-  public Manager() {
+  Manager(Phone phone) {
+    this.phone = phone;
   }
 
   @Override

--- a/project/src/com/google/daggerquery/example/models/Manager.java
+++ b/project/src/com/google/daggerquery/example/models/Manager.java
@@ -1,0 +1,33 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Manager implements Staff {
+  @Inject
+  Phone phone;
+
+  @Inject
+  public Manager() {
+  }
+
+  @Override
+  public void help() {
+    System.out.println("Hotel Manager helped the tourist to organize an excursion.");
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/MiniBar.java
+++ b/project/src/com/google/daggerquery/example/models/MiniBar.java
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class MiniBar {
+  @Inject
+  CocaCola cocaCola;
+
+  @Inject
+  Fanta fanta;
+
+  @Inject
+  Sprite sprite;
+
+  @Inject
+  public MiniBar() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/MiniBar.java
+++ b/project/src/com/google/daggerquery/example/models/MiniBar.java
@@ -19,16 +19,14 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class MiniBar {
-  @Inject
-  CocaCola cocaCola;
+  private final CocaCola cocaCola;
+  private final Fanta fanta;
+  private final Sprite sprite;
 
   @Inject
-  Fanta fanta;
-
-  @Inject
-  Sprite sprite;
-
-  @Inject
-  public MiniBar() {
+  MiniBar(CocaCola cocaCola, Fanta fanta, Sprite sprite) {
+    this.cocaCola = cocaCola;
+    this.fanta = fanta;
+    this.sprite = sprite;
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Phone.java
+++ b/project/src/com/google/daggerquery/example/models/Phone.java
@@ -1,0 +1,36 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+import java.util.Random;
+
+public class Phone {
+  private String model;
+
+  @Inject
+  public Phone() {
+    switch (Math.abs((new Random().nextInt()) % 2)) {
+      case 0:
+        model = "Google Pixel 4 XL";
+        break;
+      case 1:
+        model = "iPhone XS";
+        break;
+    }
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Phone.java
+++ b/project/src/com/google/daggerquery/example/models/Phone.java
@@ -23,7 +23,7 @@ public class Phone {
   private String model;
 
   @Inject
-  public Phone() {
+  Phone() {
     switch (Math.abs((new Random().nextInt()) % 2)) {
       case 0:
         model = "Google Pixel 4 XL";

--- a/project/src/com/google/daggerquery/example/models/Pool.java
+++ b/project/src/com/google/daggerquery/example/models/Pool.java
@@ -19,16 +19,14 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class Pool {
-  @Inject
-  InflatableDonut inflatableDonut;
+  private final InflatableDonut inflatableDonut;
+  private final InflatableFlamingo inflatableFlamingo;
+  private final InflatableUnicorn inflatableUnicorn;
 
   @Inject
-  InflatableFlamingo inflatableFlamingo;
-
-  @Inject
-  InflatableUnicorn inflatableUnicorn;
-
-  @Inject
-  Pool() {
+  Pool(InflatableUnicorn unicorn, InflatableFlamingo flamingo, InflatableDonut donut) {
+    this.inflatableDonut = donut;
+    this.inflatableFlamingo = flamingo;
+    this.inflatableUnicorn = unicorn;
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Pool.java
+++ b/project/src/com/google/daggerquery/example/models/Pool.java
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Pool {
+  @Inject
+  InflatableDonut inflatableDonut;
+
+  @Inject
+  InflatableFlamingo inflatableFlamingo;
+
+  @Inject
+  InflatableUnicorn inflatableUnicorn;
+
+  @Inject
+  Pool() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Sprite.java
+++ b/project/src/com/google/daggerquery/example/models/Sprite.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class Sprite {
   @Inject
-  public Sprite() {
+  Sprite() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Sprite.java
+++ b/project/src/com/google/daggerquery/example/models/Sprite.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Sprite {
+  @Inject
+  public Sprite() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Staff.java
+++ b/project/src/com/google/daggerquery/example/models/Staff.java
@@ -1,0 +1,21 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+public interface Staff {
+  void help();
+}

--- a/project/src/com/google/daggerquery/example/models/TV.java
+++ b/project/src/com/google/daggerquery/example/models/TV.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class TV {
+  @Inject
+  public TV() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/TV.java
+++ b/project/src/com/google/daggerquery/example/models/TV.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class TV {
   @Inject
-  public TV() {
+  TV() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Tourist.java
+++ b/project/src/com/google/daggerquery/example/models/Tourist.java
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Tourist {
+  @Inject
+  Towel towel;
+
+  @Inject
+  Phone phone;
+
+  @Inject
+  public Tourist() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Tourist.java
+++ b/project/src/com/google/daggerquery/example/models/Tourist.java
@@ -19,13 +19,12 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class Tourist {
-  @Inject
-  Towel towel;
+  private final Towel towel;
+  private final Phone phone;
 
   @Inject
-  Phone phone;
-
-  @Inject
-  public Tourist() {
+  Tourist(Towel towel, Phone phone) {
+    this.towel = towel;
+    this.phone = phone;
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Towel.java
+++ b/project/src/com/google/daggerquery/example/models/Towel.java
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Towel {
+  @Inject
+  public Towel() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/models/Towel.java
+++ b/project/src/com/google/daggerquery/example/models/Towel.java
@@ -20,6 +20,6 @@ import javax.inject.Inject;
 
 public class Towel {
   @Inject
-  public Towel() {
+  Towel() {
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Villa.java
+++ b/project/src/com/google/daggerquery/example/models/Villa.java
@@ -19,25 +19,20 @@ package com.google.daggerquery.example.models;
 import javax.inject.Inject;
 
 public class Villa {
-  @Inject
-  Bed bed;
+  private final Bed bed;
+  private final MiniBar miniBar;
+  private final TV tv;
+  private final Phone phone;
+  private final Pool pool;
+  private final Tourist tourist;
 
   @Inject
-  MiniBar miniBar;
-
-  @Inject
-  TV tv;
-
-  @Inject
-  Phone phone;
-
-  @Inject
-  Pool pool;
-
-  @Inject
-  Tourist tourist;
-
-  @Inject
-  Villa() {
+  Villa(Bed bed, MiniBar miniBar, TV tv, Phone phone, Pool pool, Tourist tourist) {
+    this.bed = bed;
+    this.miniBar = miniBar;
+    this.tv = tv;
+    this.phone = phone;
+    this.pool = pool;
+    this.tourist = tourist;
   }
 }

--- a/project/src/com/google/daggerquery/example/models/Villa.java
+++ b/project/src/com/google/daggerquery/example/models/Villa.java
@@ -1,0 +1,43 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.models;
+
+import javax.inject.Inject;
+
+public class Villa {
+  @Inject
+  Bed bed;
+
+  @Inject
+  MiniBar miniBar;
+
+  @Inject
+  TV tv;
+
+  @Inject
+  Phone phone;
+
+  @Inject
+  Pool pool;
+
+  @Inject
+  Tourist tourist;
+
+  @Inject
+  Villa() {
+  }
+}

--- a/project/src/com/google/daggerquery/example/modules/AccommodationModule.java
+++ b/project/src/com/google/daggerquery/example/modules/AccommodationModule.java
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.modules;
+
+import com.google.daggerquery.example.models.Apartment;
+import com.google.daggerquery.example.models.Villa;
+import dagger.Module;
+import dagger.Provides;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+@Module
+public class AccommodationModule {
+  @Provides
+  Set<Apartment> provideApartments(Apartment apartment1, Apartment apartment2, Apartment apartment3) {
+    return new HashSet<>(Arrays.asList(apartment1, apartment2, apartment3));
+  }
+
+  @Provides
+  Map<Villa, Integer> provideVillas(Villa villa1, Villa villa2, Villa villa3, Villa villa4, Villa villa5) {
+    Map<Villa, Integer> map = new HashMap<>();
+    map.put(villa1, 100);
+    map.put(villa2, 200);
+    map.put(villa3, 150);
+    map.put(villa4, 170);
+    map.put(villa5, 130);
+
+    return map;
+  }
+}

--- a/project/src/com/google/daggerquery/example/modules/BUILD
+++ b/project/src/com/google/daggerquery/example/modules/BUILD
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_plugin")
-load("//src/com/google/daggerquery/server:dagger_query_server.bzl", "dagger_query_server")
+load("@rules_java//java:defs.bzl", "java_library")
+load("@dagger//:workspace_defs.bzl", "dagger_rules")
 
+dagger_rules()
 package(default_visibility = ["//visibility:public"])
 
-java_plugin(
-    name = "dagger_query_plugin",
+java_library(
+    name = "example_modules",
+    srcs = glob(["*.java"]),
     deps = [
-        "//src/com/google/daggerquery/plugin:plugin_sources",
-    ]
-)
-
-dagger_query_server(
-    name = "example_java_server",
-    dagger_app_target = "//src/com/google/daggerquery/example:beach_example"
+        "//src/com/google/daggerquery/example/models:example_models",
+        ":dagger",
+    ],
 )

--- a/project/src/com/google/daggerquery/example/modules/PeopleModule.java
+++ b/project/src/com/google/daggerquery/example/modules/PeopleModule.java
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+ */
+
+package com.google.daggerquery.example.modules;
+
+import com.google.daggerquery.example.models.Lifeguard;
+import com.google.daggerquery.example.models.Manager;
+import com.google.daggerquery.example.models.Staff;
+import com.google.daggerquery.example.models.Tourist;
+import dagger.Module;
+import dagger.Provides;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Module
+public class PeopleModule {
+  @Provides
+  Set<Staff> provideLifeguards(Lifeguard lifeguard1, Lifeguard lifeguard2, Lifeguard lifeguard3) {
+    return new HashSet<>(Arrays.asList(lifeguard1, lifeguard2, lifeguard3));
+  }
+
+  @Provides
+  List<Staff> provideManagers(Manager manager1, Manager manager2, Manager manager3, Manager manager4) {
+    return Arrays.asList(manager1, manager2, manager3, manager4);
+  }
+
+  @Provides
+  Set<Tourist> provideTourists(Tourist tourist1, Tourist tourist2, Tourist tourist3, Tourist tourist4) {
+    return new HashSet<>(Arrays.asList(tourist1, tourist2, tourist3, tourist4));
+  }
+}


### PR DESCRIPTION
Add an example target which was build with [Dagger](https://dagger.dev/) framework.

This target contains several files that simply describe the relationships between objects located in a vacation spot. The object diagram is below.

### To start a server with a connected target:
```
cd project
bazel run src/com/google/daggerquery:example_java_server
```

### Queries examples:
* **allpaths** com.google.daggerquery.example.HotelComponent com.google.daggerquery.example.models.CocaCola
* **somepath** com.google.daggerquery.example.HotelComponent com.google.daggerquery.example.models.Sprite 
* **deps** com.google.daggerquery.example.models.Villa

![unnamed](https://user-images.githubusercontent.com/19249980/93254267-c16a0400-f7a0-11ea-9192-7c5df04ec944.png)

_Note: Components are highlighted with yellow, containers which were created via `@Provides` annotation with pink and other nodes with blue._

