### PR TITLE
Supports RDEPS query 🏔

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/Graph.java
+++ b/project/src/com/google/daggerquery/executor/models/Graph.java
@@ -31,6 +31,11 @@ public interface Graph {
   ImmutableSet<String> getDependencies(String node);
 
   /**
+   * Returns all node's ancestors.
+   */
+  ImmutableSet<String> getAncestors(String node);
+
+  /**
    * Checks if a node is presented in the graph or not.
    */
   boolean containsNode(String node);

--- a/project/src/com/google/daggerquery/executor/models/Graph.java
+++ b/project/src/com/google/daggerquery/executor/models/Graph.java
@@ -31,7 +31,7 @@ public interface Graph {
   ImmutableSet<String> getDependencies(String node);
 
   /**
-   * Returns all node's ancestors.
+   * Returns all of a node's ancestors (nodes that depend on this node).
    */
   ImmutableSet<String> getAncestors(String node);
 

--- a/project/src/com/google/daggerquery/executor/models/GraphProto.java
+++ b/project/src/com/google/daggerquery/executor/models/GraphProto.java
@@ -37,26 +37,7 @@ public class GraphProto implements Graph {
 
   public GraphProto(BindingGraph bindingGraph) {
     this.bindingGraph = bindingGraph;
-
-    Map<String, ImmutableSet.Builder<String>> reversedGraphModel = new HashMap<>();
-
-    for (String source: bindingGraph.getAdjacencyListMap().keySet()) {
-      reversedGraphModel.put(source, new ImmutableSet.Builder<>());
-    }
-
-    for (String source: bindingGraph.getAdjacencyListMap().keySet()) {
-      for (Dependency dependency: bindingGraph.getAdjacencyListMap().get(source).getDependencyList()) {
-        String target = dependency.getTarget();
-        reversedGraphModel.get(target).add(source);
-      }
-    }
-
-    this.reversedBindingGraph = ImmutableMap.copyOf(
-      Maps.transformValues(
-        reversedGraphModel,
-        ImmutableSet.Builder::build
-      )
-    );
+    this.reversedBindingGraph = makeBindingReversedGraph(bindingGraph);
   }
 
   @Override
@@ -78,5 +59,32 @@ public class GraphProto implements Graph {
   @Override
   public ImmutableSet<String> getAllNodes() {
     return ImmutableSet.copyOf(bindingGraph.getAdjacencyListMap().keySet());
+  }
+
+  /**
+   * Makes a reversed binding graph from the given {@code sourceBindingGraph}.
+   *
+   * <p>A reverse graph is created by reversing the direction of each edge of the original graph.
+   */
+  private ImmutableMap<String, ImmutableSet<String>> makeBindingReversedGraph(BindingGraph sourceBindingGraph) {
+    Map<String, ImmutableSet.Builder<String>> reversedGraphModel = new HashMap<>();
+
+    for (String source: sourceBindingGraph.getAdjacencyListMap().keySet()) {
+      reversedGraphModel.put(source, new ImmutableSet.Builder<>());
+    }
+
+    for (String source: sourceBindingGraph.getAdjacencyListMap().keySet()) {
+      for (Dependency dependency: sourceBindingGraph.getAdjacencyListMap().get(source).getDependencyList()) {
+        String target = dependency.getTarget();
+        reversedGraphModel.get(target).add(source);
+      }
+    }
+
+    return ImmutableMap.copyOf(
+      Maps.transformValues(
+        reversedGraphModel,
+        ImmutableSet.Builder::build
+      )
+    );
   }
 }

--- a/project/src/com/google/daggerquery/executor/models/GraphProto.java
+++ b/project/src/com/google/daggerquery/executor/models/GraphProto.java
@@ -16,9 +16,13 @@ limitations under the License.
 
 package com.google.daggerquery.executor.models;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto.BindingGraph;
 import com.google.daggerquery.protobuf.autogen.DependencyProto.Dependency;
+import java.util.HashMap;
+import java.util.Map;
 
 import static java.util.stream.Collectors.toSet;
 
@@ -29,15 +33,41 @@ import static java.util.stream.Collectors.toSet;
 public class GraphProto implements Graph {
 
   private BindingGraph bindingGraph;
+  private ImmutableMap<String, ImmutableSet<String>> reversedBindingGraph;
 
   public GraphProto(BindingGraph bindingGraph) {
     this.bindingGraph = bindingGraph;
+
+    Map<String, ImmutableSet.Builder<String>> reversedGraphModel = new HashMap<>();
+
+    for (String source: bindingGraph.getAdjacencyListMap().keySet()) {
+      reversedGraphModel.put(source, new ImmutableSet.Builder<>());
+    }
+
+    for (String source: bindingGraph.getAdjacencyListMap().keySet()) {
+      for (Dependency dependency: bindingGraph.getAdjacencyListMap().get(source).getDependencyList()) {
+        String target = dependency.getTarget();
+        reversedGraphModel.get(target).add(source);
+      }
+    }
+
+    this.reversedBindingGraph = ImmutableMap.copyOf(
+      Maps.transformValues(
+        reversedGraphModel,
+        ImmutableSet.Builder::build
+      )
+    );
   }
 
   @Override
   public ImmutableSet<String> getDependencies(String node) {
     return ImmutableSet.copyOf(bindingGraph.getAdjacencyListMap().get(node).getDependencyList()
         .stream().map(Dependency::getTarget).sorted().collect(toSet()));
+  }
+
+  @Override
+  public ImmutableSet<String> getAncestors(String node) {
+    return reversedBindingGraph.get(node);
   }
 
   @Override

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -43,6 +43,7 @@ public class Query {
   private final static String DEPS_QUERY_NAME = "deps";
   private final static String ALLPATHS_QUERY_NAME = "allpaths";
   private final static String SOMEPATH_QUERY_NAME = "somepath";
+  private final static String RDEPS_QUERY_NAME = "rdeps";
 
   private final static int MAX_NUMBER_OF_MISPLACED_LETTERS = 3;
 
@@ -54,6 +55,7 @@ public class Query {
       .put(DEPS_QUERY_NAME, 1)
       .put(ALLPATHS_QUERY_NAME, 2)
       .put(SOMEPATH_QUERY_NAME, 2)
+      .put(RDEPS_QUERY_NAME, 1)
       .build();
 
   private String name;
@@ -141,6 +143,13 @@ public class Query {
         }
 
         return ImmutableList.copyOf(Arrays.asList(path.toString()));
+      }
+      case RDEPS_QUERY_NAME: {
+        String source = parameters[0];
+
+        checkNodeForCorrectness(source, bindingGraph);
+
+        return bindingGraph.getAncestors(source).asList();
       }
     }
 

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -26,6 +26,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto;
 import com.google.daggerquery.protobuf.autogen.DependencyProto;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
@@ -364,6 +365,102 @@ public class QueryTest {
     Query query = new Query("somepath", parameters);
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
+  }
+
+  // Tests for `RDEPS` query
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsingRdepsQuery_WithTwoStringParameters_ThrowsIllegalArgumentException() {
+    Query query = new Query("rdeps", "com.google.cats.FirstCat", "com.google.cats.SecondCat");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testParsingRdepsQuery_WithoutParameters_ThrowsIllegalArgumentException() {
+    Query query = new Query("rdeps");
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testParsingRdepsQuery_WithNullParameters_ThrowsNullPointerException() {
+    Query query = new Query("rdeps", /*parameters = */ null);
+  }
+
+  @Test
+  public void testExecutingRdepsQuery_WithFactorySourceNode() {
+    String[] parameters = {"com.google.CatsFactory"};
+    Query query = new Query("rdeps", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
+
+    assertEquals(Collections.singletonList("com.google.Component"), queryExecutionResult);
+  }
+
+  @Test
+  public void testExecutingRdepsQuery_WithCapitalizedName_WithFactorySourceNode() {
+    String[] parameters = {"com.google.CatsFactory"};
+    Query query = new Query("RDePs", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
+
+    assertEquals(Collections.singletonList("com.google.Component"), queryExecutionResult);
+  }
+
+  @Test
+  public void testExecutingRdepsQuery_WithDetailsSourceNode() {
+    String[] parameters = {"com.google.Details"};
+    Query query = new Query("rdeps", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
+
+    ImmutableSet expectedOutput = ImmutableSet.of("com.google.Component", "com.google.Cat");
+    assertEquals(expectedOutput, ImmutableSet.copyOf(queryExecutionResult));
+  }
+
+  @Test
+  public void testExecutingRdepsQuery_WithRootAsSourceNode() {
+    String[] parameters = {"com.google.Component"};
+    Query query = new Query("rdeps", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
+
+    assertEquals(0, queryExecutionResult.size());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecutingRdepsQuery_WithAbsentSourceNode_ThrowsIllegalArgumentException() {
+    String[] parameters = {"com.google.Kitten"};
+    Query query = new Query("rdeps", parameters);
+
+    query.execute(makeSimpleBindingGraph());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void testExecutingRdepsQuery_WithNullBindingGraph_ThrowsNullPointerException() {
+    String[] parameters = {"com.google.Cat"};
+    Query query = new Query("rdeps", parameters);
+
+    query.execute(null);
+  }
+
+  @Test
+  public void testExecutingRdepsQuery_WithOneTypoInNodeName_ThrowsMisspelledNodeNameException() {
+    try {
+      String[] parameters = {"com.google.CatsFactoryy"};
+      Query query = new Query("rdeps", parameters);
+
+      List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
+      fail();
+    } catch (MisspelledNodeNameException e) {
+      // We do not care too much about the rest of the message, but it should contain a correct node name.
+      assertTrue(e.getMessage().contains("com.google.CatsFactory"));
+    }
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testExecutingRdepsQuery_WithTooManyTyposInNodeName_ThrowsIllegalArgumentException() {
+    String[] parameters = {"com.google.CatsFactory...."};
+    Query query = new Query("rdeps", parameters);
+
+    List<String> queryExecutionResult = query.execute(makeSimpleBindingGraph());
   }
 
   /*


### PR DESCRIPTION
Supports `rdeps` query and covers implementation with tests.

Here is a trade-off between time and memory. We care about the time complexity of queries more so the solution is to save the reversed binding graph. That's will take us O(1) to get all ancestors of the source node.

This query was created to support showing all ancestors in Dagger Query UI. However, it will be available in the command-line app too and can be quite useful. 

**Main changes:**
* `rdeps` query implementation in the `Query` class
* creating the reversed binding graph in `GraphProto` constructor 
* extending `Graph` interface with method which return all ancestors
* adding tests in `QueryTest` class