### PR TITLE
Saves all exceptions and prioritises them after execution 🛍

### DIFF
--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -124,6 +125,11 @@ public class Query {
         Path path = new Path<>();
 
         findAllPaths(source, target, path, bindingGraph, visitedNodes, result);
+
+        if (result.build().isEmpty() || source.equals(target)) {
+          throw new NoSuchElementException("Nothing found, list with results is empty.");
+        }
+
         return ImmutableList.copyOf(result.build().stream().map(Path::toString).collect(toList()));
       }
       case SOMEPATH_QUERY_NAME: {
@@ -136,8 +142,9 @@ public class Query {
         Path path = new Path<>();
 
         findSomePath(source, target, path, bindingGraph, visitedNodes);
-        if (path.isEmpty()) {
-          return ImmutableList.of();
+
+        if (path.isEmpty() || source.equals(target)) {
+          throw new NoSuchElementException("Nothing found, list with results is empty.");
         }
 
         return ImmutableList.copyOf(Arrays.asList(path.toString()));

--- a/project/tests/com/google/daggerquery/executor/models/QueryTest.java
+++ b/project/tests/com/google/daggerquery/executor/models/QueryTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.Sets;
 import com.google.daggerquery.protobuf.autogen.BindingGraphProto;
 import com.google.daggerquery.protobuf.autogen.DependencyProto;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.Set;
 import org.junit.Test;
 
@@ -192,24 +193,20 @@ public class QueryTest {
     assertTrue(queryExecutionResult.containsAll(expectedOutput) && expectedOutput.containsAll(queryExecutionResult));
   }
 
-  @Test
+  @Test(expected = NoSuchElementException.class)
   public void testExecutingAllPathsQuery_WithLeafAsSourceNode() {
     String[] parameters = {"com.google.Details", "com.google.Component"};
     Query query = new Query("allpaths", parameters);
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
-
-    assertEquals(0, queryExecutionResult.size());
   }
 
-  @Test
+  @Test(expected = NoSuchElementException.class)
   public void testExecutingAllPathsQuery_WhenThereIsNoPaths() {
     String[] parameters = {"com.google.CatsFactory", "com.google.Helper"};
     Query query = new Query("allpaths", parameters);
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
-
-    assertEquals(0, queryExecutionResult.size());
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -308,24 +305,20 @@ public class QueryTest {
     assertTrue(possibleOutputs.contains(queryExecutionResult.get(0)));
   }
 
-  @Test
+  @Test(expected = NoSuchElementException.class)
   public void testExecutingSomePathQuery_WithLeafAsSourceNode() {
     String[] parameters = {"com.google.Details", "com.google.Component"};
     Query query = new Query("somepath", parameters);
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
-
-    assertEquals(0, queryExecutionResult.size());
   }
 
-  @Test
+  @Test(expected = NoSuchElementException.class)
   public void testExecutingSomePathQuery_WhenThereIsNoPaths() {
     String[] parameters = {"com.google.CatsFactory", "com.google.Helper"};
     Query query = new Query("somepath", parameters);
 
     List<String> queryExecutionResult = query.execute(makeBindingGraph_WithMultiplePathsBetweenTwoNodes());
-
-    assertEquals(0, queryExecutionResult.size());
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Saves all exceptions in one set and prioritises them after all queries execution.

**Problem:** There are can be a situation when we have multiple graphs, and users type a query which result is empty (but source node exists). The result can depend on the order of out binding graphs because we remember only the last thrown `IllegalArgumentException`. And exception which indicates that the source node is missing in the last graph can overlap the previous exception, that no paths exist.

**Solution:** Let's save all raised exceptions in one set and then pick the first one. Each exception saved paired with an integer which represents a priority of exception (`1` means that exception is the most significant).