### PR TITLE
Preprocesses node key before serialization

### DIFF
--- a/project/src/com/google/daggerquery/plugin/GraphConverter.java
+++ b/project/src/com/google/daggerquery/plugin/GraphConverter.java
@@ -106,12 +106,15 @@ public class GraphConverter<NodeT, EdgeT> {
    * For other nodes returns their string representation constructed with {@code toString()} method.
    */
   private String makeStringFromNode(NodeT node) {
+    String nodeName;
     if (node instanceof Binding) {
-      return ((Binding) node).key().toString();
+      nodeName = ((Binding) node).key().toString();
     } else if (node instanceof BindingGraph.ComponentNode) {
-      return ((BindingGraph.ComponentNode) node).componentPath().currentComponent().toString();
+      nodeName = ((BindingGraph.ComponentNode) node).componentPath().currentComponent().toString();
+    } else {
+      nodeName = node.toString();
     }
 
-    return node.toString();
+    return nodeName.replace("<", "[").replace(">", "]");
   }
 }

--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -49,10 +49,8 @@ const bindingGraph = (function() {
 
     const id = nodesToNumbers.get(node);
     if (nodes.get(id) === null) {
-      // Since angle brackets have a special meaning in html, we replace them with square brackets.
-      const fullName = node.replace(/</g, "[").replace(/>/g, "]");
-      const simpleName = fullName.replace(/(?:\w+\.)+(\w+)/g, '$1');
-      nodes.add({id: id, label: simpleName, title: fullName});
+      const simpleName = node.replace(/(?:\w+\.)+(\w+)/g, '$1');
+      nodes.add({id: id, label: simpleName, title: node});
     }
     return id;
   }


### PR DESCRIPTION
Preprocesses node key name before serialization by replacing angle brackets with squared.

Since angle brackets (<, >) have special meaning in HTML, there are some troubles with showing the correct name of a node in HTML blocks. To avoid replacing it everywhere, let's serialise node keys with squared brackets instead of angle ones.