### PR TITLE
Supports clicks on the nodes

### DIFF
--- a/project/src/com/google/daggerqueryui/scripts/analyze_input_field_content.js
+++ b/project/src/com/google/daggerqueryui/scripts/analyze_input_field_content.js
@@ -87,7 +87,7 @@ const queryExecutor = (function() {
      * @param {string[]} query a valid query which will be executed
      * @param {boolean} shouldClearGraph a flag which indicates if the graph should be cleaned or not
      */
-    processQuery: async function(query, shouldClearGraph) {
+    processQuery: async function(query, {shouldClearGraph}) {
       try {
         const url = new URL(`http://localhost:4921/daggerquery/`);
         url.searchParams.append('query', query.join(' '));
@@ -128,6 +128,6 @@ $("#query-input").on('keyup', function (event) {
   queryNameElement.html(queryName).show();
 
   if (event.key === 'Enter' && $(this).validateParameters(query)) {
-    queryExecutor.processQuery(query, true);
+    queryExecutor.processQuery(query, {shouldClearGraph: true});
   }
 });

--- a/project/src/com/google/daggerqueryui/scripts/analyze_input_field_content.js
+++ b/project/src/com/google/daggerqueryui/scripts/analyze_input_field_content.js
@@ -63,13 +63,13 @@ $(function () {
   };
 });
 
-$(function () {
+const queryExecutor = (function() {
   /**
    * Sends a request to the server with specified query and gets a response.
    * @param url an address with the correct path and request parameters in it
    * @return {Promise<any>} a promise that contains a json with a graph on success
    */
-  $.fn.getQueryResults = async function (url) {
+  async function getQueryResults(url) {
     let response = await fetch(url);
 
     if (response.status === 200) {
@@ -77,37 +77,42 @@ $(function () {
     }
 
     throw await response.text();
-  };
-
-  /**
-   * Processes a valid query by sending a request to the specified URL,
-   * receiving a response, and performing UI actions in response.
-   *
-   * @param {string[]} query a valid query which will be executed
-   */
-  $.fn.processQuery = async function (query) {
-    try {
-      const url = new URL(`http://localhost:4921/daggerquery/`);
-      url.searchParams.append('query', query.join(' '));
-      const results = await $(this).getQueryResults(url);
-      $(this).markInputFieldAsValid();
-
-      if (query[0] === $.DEPS_QUERY_NAME) {
-        bindingGraph.clear();
-        bindingGraph.addDeps(query[1], results);
-      } else if (query[0] === $.ALLPATHS_QUERY_NAME || query[0] === $.SOMEPATH_QUERY_NAME) {
-        bindingGraph.clear();
-        for (let path of results) {
-          bindingGraph.addPath(path);
-        }
-      }
-
-      bindingGraph.draw();
-    } catch (error) {
-      $(this).markInputFieldAsInvalid(error);
-    }
   }
-});
+
+  return {
+    /**
+     * Processes a valid query by sending a request to the specified URL,
+     * receiving a response, and performing UI actions in response.
+     *
+     * @param {string[]} query a valid query which will be executed
+     * @param {boolean} shouldClearGraph a flag which indicates if the graph should be cleaned or not
+     */
+    processQuery: async function(query, shouldClearGraph) {
+      try {
+        const url = new URL(`http://localhost:4921/daggerquery/`);
+        url.searchParams.append('query', query.join(' '));
+        const results = await getQueryResults(url);
+        $(this).markInputFieldAsValid();
+
+        if (shouldClearGraph) {
+          bindingGraph.clear();
+        }
+
+        if (query[0] === $.DEPS_QUERY_NAME) {
+          bindingGraph.addDeps(query[1], results);
+        } else if (query[0] === $.ALLPATHS_QUERY_NAME || query[0] === $.SOMEPATH_QUERY_NAME) {
+          for (const path of results) {
+            bindingGraph.addPath(path);
+          }
+        }
+
+        bindingGraph.draw();
+      } catch (error) {
+        $(this).markInputFieldAsInvalid(error);
+      }
+    }
+  };
+})();
 
 $("#query-input").on('keyup', function (event) {
   const query = $(this).val().trim().split(' ');
@@ -123,6 +128,6 @@ $("#query-input").on('keyup', function (event) {
   queryNameElement.html(queryName).show();
 
   if (event.key === 'Enter' && $(this).validateParameters(query)) {
-    $(this).processQuery(query);
+    queryExecutor.processQuery(query, true);
   }
 });

--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -168,6 +168,38 @@ const bindingGraph = (function() {
   }
 
   /**
+   * If the dependencies are not currently shown, we prefer to draw them all.
+   * Otherwise, we hide all children, even if they are not all were presented.
+   *
+   * @param {number} nodeId
+   */
+  function showOrHideDeps(nodeId) {
+    const nodeTitle = nodes.get(nodeId).title;
+
+    if (getAllEdgesToDeps(nodeId).length === 0) {
+      queryExecutor.processQuery(['deps', nodeTitle], false);
+    } else {
+      bindingGraph.deleteDeps(nodeTitle);
+    }
+  }
+
+  /**
+   * If the ancestors are not currently shown, we prefer to draw them all.
+   * Otherwise, we hide all parents, even if they are not all were presented.
+   *
+   * @param {number} nodeId
+   */
+  function showOrHideAncestors(nodeId) {
+    const nodeTitle = nodes.get(nodeId).title;
+
+    if (getAllEdgesFromAncestors(nodeId).length === 0) {
+      queryExecutor.processQuery(['rdeps', nodeTitle], false);
+    } else {
+      bindingGraph.deleteAncestors(nodeTitle);
+    }
+  }
+
+  /**
    * Supports click and double click events in the network object.
    * @param {vis.Network} network
    */
@@ -180,15 +212,7 @@ const bindingGraph = (function() {
       }
 
       const nodeId = params.nodes[0];
-      const nodeTitle = nodes.get(nodeId).title;
-
-      // If the dependencies are not currently shown, we prefer to draw them all.
-      // Otherwise, we hide all children, even if they are not all were presented.
-      if (getAllEdgesToDeps(nodeId).length === 0) {
-        queryExecutor.processQuery(['deps', nodeTitle], false);
-      } else {
-        bindingGraph.deleteDeps(nodeTitle);
-      }
+      showOrHideDeps(nodeId);
     });
 
     // An event for managing parent nodes.
@@ -199,15 +223,7 @@ const bindingGraph = (function() {
       }
 
       const nodeId = params.nodes[0];
-      const nodeTitle = nodes.get(nodeId).title;
-
-      // If the ancestors are not currently shown, we prefer to draw them all.
-      // Otherwise, we hide all parents, even if they are not all were presented.
-      if (getAllEdgesFromAncestors(nodeId).length === 0) {
-        queryExecutor.processQuery(['rdeps', nodeTitle], false);
-      } else {
-        bindingGraph.deleteAncestors(nodeTitle);
-      }
+      showOrHideAncestors(nodeId);
     });
   }
 

--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -172,7 +172,8 @@ const bindingGraph = (function() {
    * @param {vis.Network} network
    */
   function supportEventsRecognition(network) {
-    network.on("click", function (params) {
+    // An event for managing children nodes.
+    network.on("doubleClick", function (params) {
       // Checks if any node was selected.
       if (params.nodes.length === 0) {
         return;
@@ -190,7 +191,8 @@ const bindingGraph = (function() {
       }
     });
 
-    network.on("doubleClick", function (params) {
+    // An event for managing parent nodes.
+    network.on("oncontext", function (params) {
       // Checks if any node was selected.
       if (params.nodes.length === 0) {
         return;

--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -200,12 +200,12 @@ const bindingGraph = (function() {
   }
 
   /**
-   * Supports click and double click events in the network object.
+   * Supports right-click and left-click events in the network object.
    * @param {vis.Network} network
    */
   function supportEventsRecognition(network) {
     // An event for managing children nodes.
-    network.on("doubleClick", function (params) {
+    network.on("click", function (params) {
       // Checks if any node was selected.
       if (params.nodes.length === 0) {
         return;

--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -34,7 +34,18 @@ const bindingGraph = (function() {
   /**
    * Specific options of the binding graph.
    */
-  const options = {physics: false};
+  const options = {
+    physics: false,
+    layout: {
+      randomSeed: 42,
+    }
+  };
+
+  /**
+   * Determines if graph needs to be redrawn or not.
+   * @type {boolean}
+   */
+  let needsToRedraw = true;
 
   /**
    * Associates given node with an identifier, if the node was not represented in the graph.
@@ -91,7 +102,7 @@ const bindingGraph = (function() {
    *
    * @param {number} nodeId an identifier of the given node
    */
-  function getAllDeps(nodeId) {
+  function getAllEdgesToDeps(nodeId) {
     return edges.get({
       filter: function (edge) {
         return (edge.from === nodeId);
@@ -100,15 +111,33 @@ const bindingGraph = (function() {
   }
 
   /**
+   * Retrieves all edges where the target node is the specified one.
+   *
+   * @param {number} nodeId an identifier of the given node
+   */
+  function getAllEdgesFromAncestors(nodeId) {
+    return edges.get({
+      filter: edge => edge.to === nodeId
+    });
+  }
+
+  /**
    * Removes an edge from a subgraph, and if the destination node
    * becomes isolated, then removes it as well.
    *
-   * @param edge an edge which will be removed
+   * @param {vis.Edge} edge an edge which will be removed
+   * @param {boolean} shouldRemoveSource
+   * @param {boolean} shouldRemoveTarget
    */
-  function removeEdge(edge) {
+  function removeEdge(edge, shouldRemoveSource, shouldRemoveTarget) {
     edges.remove(edge);
 
-    tryToRemoveNode(edge.to);
+    if (shouldRemoveSource) {
+      tryToRemoveNode(edge.from);
+    }
+    if (shouldRemoveTarget) {
+      tryToRemoveNode(edge.to);
+    }
   }
 
   /**
@@ -144,6 +173,48 @@ const bindingGraph = (function() {
     }).length !== 0;
   }
 
+  /**
+   * Supports click and double click events in the network object.
+   * @param {vis.Network} network
+   */
+  function supportEventsRecognition(network) {
+    network.on("click", function (params) {
+      // Checks if any node was selected.
+      if (params.nodes.length === 0) {
+        return;
+      }
+
+      const nodeId = params.nodes[0];
+      const nodeTitle = nodes.get(nodeId).title;
+
+      // If the dependencies are not currently shown, we prefer to draw them all.
+      // Otherwise, we hide all children, even if they are not all were presented.
+      if (getAllEdgesToDeps(nodeId).length === 0) {
+        queryExecutor.processQuery(['deps', nodeTitle], false);
+      } else {
+        bindingGraph.deleteDeps(nodeTitle);
+      }
+    });
+
+    network.on("doubleClick", function (params) {
+      // Checks if any node was selected.
+      if (params.nodes.length === 0) {
+        return;
+      }
+
+      const nodeId = params.nodes[0];
+      const nodeTitle = nodes.get(nodeId).title;
+
+      // If the ancestors are not currently shown, we prefer to draw them all.
+      // Otherwise, we hide all parents, even if they are not all were presented.
+      if (getAllEdgesFromAncestors(nodeId).length === 0) {
+        queryExecutor.processQuery(['rdeps', nodeTitle], false);
+      } else {
+        bindingGraph.deleteAncestors(nodeTitle);
+      }
+    });
+  }
+
   return {
     /**
      * Takes a string representing a path where two adjacent nodes are connected by an edge,
@@ -168,6 +239,33 @@ const bindingGraph = (function() {
     addDeps: function (source, deps) {
       for (const childNode of deps) {
         addEdge(source, childNode);
+      }
+    },
+
+    /**
+     * Removes all edges with the given source node from the subgraph.
+     *
+     * @param {string} node a source node which dependencies will be removed
+     */
+    deleteDeps: function (node) {
+      // Retrieves all edges having a start node with value `node`.
+      const edgesToBeRemoved = getAllEdgesToDeps(nodesToNumbers.get(node));
+
+      for (const edge of edgesToBeRemoved) {
+        removeEdge(edge, /*shouldRemoveSource =*/ false, /*shouldRemoveTarget =*/ true);
+      }
+    },
+
+    /**
+     * Removes all edges with the given target node from the subgraph.
+     *
+     * @param {string} node a target node which parents will be removed
+     */
+    deleteAncestors: function (node) {
+      const edgesToBeRemoved = getAllEdgesFromAncestors(nodesToNumbers.get(node));
+
+      for (const edge of edgesToBeRemoved) {
+        removeEdge(edge, /*shouldRemoveSource =*/ true, /*shouldRemoveTarget =*/ false);
       }
     },
 
@@ -209,6 +307,7 @@ const bindingGraph = (function() {
      */
     togglePhysics: function() {
       options.physics = !options.physics;
+      needsToRedraw = true;
       return options.physics;
     },
 
@@ -216,13 +315,24 @@ const bindingGraph = (function() {
      * Draws the entire graph and sets events listeners.
      */
     draw: function() {
+      if (!needsToRedraw) {
+        return;
+      }
+
       const container = document.getElementById('binding-graph');
       const data = {
         nodes: nodes,
         edges: edges
       };
 
-      const network = new vis.Network(container, data, options);
-    }
+      network = new vis.Network(container, data, options);
+      supportEventsRecognition(network);
+
+      // With physics enabled, we don't need to draw the graph again, because the nodes are located by gravity.
+      // Otherwise, all the nodes will appear in the initial position and overlap, so we need to redraw the graph.
+      if (options.physics) {
+        needsToRedraw = false;
+      }
+    },
   };
 })();

--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -85,7 +85,7 @@ const bindingGraph = (function() {
   }
 
   /**
-   * Retrieves all edges where the start or destination nodes are equal to the given one.
+   * Retrieves all edges where the given node equals to the source or target nodes.
    *
    * @param {number} nodeId an identifier of the given node
    */
@@ -96,7 +96,7 @@ const bindingGraph = (function() {
   }
 
   /**
-   * Retrieves all edges where the start node is the specified one.
+   * Retrieves all edges where the given node equals to the source node.
    *
    * @param {number} nodeId an identifier of the given node
    */
@@ -107,7 +107,7 @@ const bindingGraph = (function() {
   }
 
   /**
-   * Retrieves all edges where the target node is the specified one.
+   * Retrieves all edges where the given node equals to the target node.
    *
    * @param {number} nodeId an identifier of the given node
    */

--- a/project/src/com/google/daggerqueryui/tests/binding_graph_test.js
+++ b/project/src/com/google/daggerqueryui/tests/binding_graph_test.js
@@ -28,7 +28,7 @@ describe('Binding Graph', function() {
   });
 
   it('extracts the simple name from the complex node name correctly', function() {
-    bindingGraph.addDeps('com.google.List<com.google.A>', ['com.google.List<com.google.common.collect.ImmutableSet<com.google.A>>']);
+    bindingGraph.addDeps('com.google.List[com.google.A]', ['com.google.List[com.google.common.collect.ImmutableSet[com.google.A]]']);
 
     assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]),
                            [[0, 'List[A]', 'com.google.List[com.google.A]'], [1, 'List[ImmutableSet[A]]', 'com.google.List[com.google.common.collect.ImmutableSet[com.google.A]]']]);
@@ -51,5 +51,73 @@ describe('Binding Graph', function() {
                            [[0, 'A', 'com.google.A'], [1, 'B', 'com.google.B'], [2, 'C', 'com.google.C'], [3, 'D', 'com.google.D'], [4, 'E', 'com.google.E']]);
     assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]),
                            [[0, 1], [1, 2], [1, 3], [3, 4]]);
+  });
+
+  it('removes all deps and isolated nodes correctly', function() {
+    bindingGraph.addDeps('com.google.A', ['com.google.B', 'com.google.C', 'com.google.D']);
+
+    const expectedNodes = [
+      [0, 'A', 'com.google.A'],
+    ];
+
+    bindingGraph.deleteDeps('com.google.A');
+
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
+    assert.isOk(bindingGraph.getEdges().length === 0);
+  });
+
+  it('removes all deps and keeps nodes correctly', function() {
+    bindingGraph.addDeps('com.google.A', ['com.google.B']);
+    bindingGraph.addDeps('com.google.C', ['com.google.B', 'com.google.D']);
+
+    const expectedNodes = [
+      [0, 'A', 'com.google.A'],
+      [1, 'B', 'com.google.B'],
+      [2, 'C', 'com.google.C'],
+      [3, 'D', 'com.google.D'],
+    ];
+    const expectedEdges = [
+      [2, 1],
+      [2, 3],
+    ];
+
+    bindingGraph.deleteDeps('com.google.A');
+
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
+    assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]), expectedEdges);
+  });
+
+  it('removes all ancestors and isolated nodes correctly', function() {
+    bindingGraph.addDeps('com.google.A', ['com.google.B']);
+    bindingGraph.addDeps('com.google.C', ['com.google.B']);
+    bindingGraph.addDeps('com.google.D', ['com.google.B']);
+
+    const expectedNodes = [
+      [1, 'B', 'com.google.B'],
+    ];
+
+    bindingGraph.deleteAncestors('com.google.B');
+
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
+    assert.isOk(bindingGraph.getEdges().length === 0);
+  });
+
+  it('removes all ancestors and keeps nodes correctly', function() {
+    bindingGraph.addDeps('com.google.A', ['com.google.B', 'com.google.C']);
+    bindingGraph.addDeps('com.google.C', ['com.google.B']);
+
+    const expectedNodes = [
+      [0, 'A', 'com.google.A'],
+      [1, 'B', 'com.google.B'],
+      [2, 'C', 'com.google.C'],
+    ];
+    const expectedEdges = [
+      [0, 2],
+    ];
+
+    bindingGraph.deleteAncestors('com.google.B');
+
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
+    assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]), expectedEdges);
   });
 });


### PR DESCRIPTION
Supports `right-click` and `double click` events in the network.

Let's use `double-click` event for showing dependencies. If at least one dependency has been already shown, then `double-click` on a node will hide all of them. Otherwise it will show all dependencies.

`Right-click` shows ancestors if they were not shown and hides all those present otherwise.

The graph redrawing logic is quite different for two modes: when **physics is disabled** all new nodes by default are placed at the one position and overlap. Therefore we need to redraw graph each time. 

![static-3](https://user-images.githubusercontent.com/19249980/93478073-533e5200-f904-11ea-87bf-98b4ff7dfa11.gif)

With **enabled physics and non-zero gravity** nodes take different places after stabilisation is finished.

![physics](https://user-images.githubusercontent.com/19249980/93469794-a52daa80-f8f9-11ea-9980-0fd5a98dfe71.gif)

[Card №1](https://github.com/googleinterns/dagger-query/projects/2#card-44227184)
[Card №2](https://github.com/googleinterns/dagger-query/projects/2#card-44227174)
