### PR TITLE
Disables context menu

### DIFF
--- a/project/src/com/google/daggerqueryui/index.html
+++ b/project/src/com/google/daggerqueryui/index.html
@@ -93,6 +93,8 @@
     <div id="error-message" class="text-danger"></div>
 </div>
 <div id="binding-graph"></div>
+<!-- Disables context menu which appears after right-clicking -->
+<script src="scripts/disable-context-menu.js" defer></script>
 <!-- Activates popover from Bootstrap -->
 <script src="scripts/enables-popover.js" defer></script>
 <!-- Setups switch for managing physics and activates tooltip from Bootstrap -->

--- a/project/src/com/google/daggerqueryui/scripts/disable-context-menu.js
+++ b/project/src/com/google/daggerqueryui/scripts/disable-context-menu.js
@@ -1,0 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+document.addEventListener('contextmenu', function (event) {
+  event.preventDefault();
+}, false);


### PR DESCRIPTION
Disables context menu which appears after `right-clicking`.

We want to use `right-click` action for showing node parents therefore we should disable context menu which always appears after `right-clicking`.