### PR TITLE
Supported EXISTS query

### DIFF
--- a/project/src/com/google/daggerquery/executor/QueryExecutor.java
+++ b/project/src/com/google/daggerquery/executor/QueryExecutor.java
@@ -85,7 +85,7 @@ public class QueryExecutor {
     }
 
     ImmutableList<String> resultList = resultBuilder.build();
-    if (resultList.isEmpty()) {
+    if (resultList.isEmpty() && exceptions.size() > 0) {
       throw new IllegalArgumentException(exceptions.entries().iterator().next().getValue().getMessage());
     } else {
       return resultList;

--- a/project/src/com/google/daggerquery/executor/models/Query.java
+++ b/project/src/com/google/daggerquery/executor/models/Query.java
@@ -45,6 +45,7 @@ public class Query {
   private final static String ALLPATHS_QUERY_NAME = "allpaths";
   private final static String SOMEPATH_QUERY_NAME = "somepath";
   private final static String RDEPS_QUERY_NAME = "rdeps";
+  private final static String EXISTS_QUERY_NAME = "exists";
 
   private final static int MAX_NUMBER_OF_MISPLACED_LETTERS = 3;
 
@@ -57,6 +58,7 @@ public class Query {
       .put(ALLPATHS_QUERY_NAME, 2)
       .put(SOMEPATH_QUERY_NAME, 2)
       .put(RDEPS_QUERY_NAME, 1)
+      .put(EXISTS_QUERY_NAME, 1)
       .build();
 
   private String name;
@@ -157,6 +159,12 @@ public class Query {
         checkNodeForCorrectness(source, bindingGraph);
 
         return bindingGraph.getAncestors(source).asList();
+      }
+      case EXISTS_QUERY_NAME: {
+        String source = parameters[0];
+
+        checkNodeForCorrectness(source, bindingGraph);
+        return ImmutableList.of(source);
       }
     }
 


### PR DESCRIPTION
Supported **EXISTS** query which returns an array with a given source node if it exists and throws an exception otherwise.

For example, in graph: `com.google.A -> com.google.B -> com.google.C` query **exists com.google.C** will return `["com.google.C"]`, but query **exists com.google.D** will fail to execute (`MisspelledNodeNameException` will be thrown). 