### PR TITLE
Selects a node after right-clicking ☀️

### DIFF
--- a/project/src/com/google/daggerqueryui/scripts/binding_graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding_graph.js
@@ -231,12 +231,13 @@ const bindingGraph = (function() {
     // An event for managing parent nodes.
     network.on("oncontext", function (params) {
       // Checks if any node was selected.
-      if (params.nodes.length === 0) {
+      const selectedNode = this.getNodeAt(params.pointer.DOM);
+      if (selectedNode === undefined) {
         return;
       }
 
-      const nodeId = params.nodes[0];
-      showOrHideAncestors(nodeId);
+      showOrHideAncestors(selectedNode);
+      this.selectNodes([selectedNode]);
     });
   }
 


### PR DESCRIPTION
Selects a node after right-clicking. 

From vis.js `oncontext` event [documentation](https://visjs.github.io/vis-network/docs/network/#event_oncontext): 
> Fired when the user click on the canvas with the right mouse button. The right mouse button does not select by default. You can use the method getNodeAt to select the node if you want.

Therefore when node wasn't selected before `params.nodes` is empty even if user clicks with right button on the node. Let's use `getNodeAt` and `selectNodes` nodes to fix this behaviour. 