### PR TITLE
Adds the bash script for launching an example

### DIFF
--- a/project/dagger-query-ui-example.sh
+++ b/project/dagger-query-ui-example.sh
@@ -1,0 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+bazel run src/com/google/daggerquery/example:beach_example
+bazel run src/com/google/daggerquery:example_java_server
+

--- a/project/dagger-query-ui-example.sh
+++ b/project/dagger-query-ui-example.sh
@@ -12,6 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bazel run src/com/google/daggerquery/example:beach_example
 bazel run src/com/google/daggerquery:example_java_server
 


### PR DESCRIPTION
Adds the bash script for launching an example which simply runs the app target, generates a binding graph and then starts a server.

**How to use it?**
```
cd project
bash ./dagger-query-ui-example.sh
```

Then just open `index.html` page from src/com/google/daggerqueryui.
