### PR TITLE
Adds button for clearing the entire graph

### DIFF
--- a/project/src/com/google/daggerqueryui/index.css
+++ b/project/src/com/google/daggerqueryui/index.css
@@ -76,3 +76,16 @@
 #query-input:invalid {
     background-image: none;
 }
+
+#clear-button-container {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    z-index: 1001;
+    margin: 16px;
+}
+
+#clear-icon {
+    width: 64px;
+    height: 64px;
+}

--- a/project/src/com/google/daggerqueryui/index.html
+++ b/project/src/com/google/daggerqueryui/index.html
@@ -36,7 +36,7 @@
 
 <div class="container" id="query-text-field">
     <div class="row align-items-center">
-        <div class="col-10">
+        <div class="col-9">
             <div class="md-form form-lg interactive-input-container">
                 <div class="form-control form-control-lg query-name"></div>
                 <input type="text"
@@ -92,13 +92,16 @@
     </div>
     <div id="error-message" class="text-danger"></div>
 </div>
+<div id="clear-button-container">
+    <img src="res/clear-button-icon.svg" id="clear-icon"/>
+</div>
 <div id="binding-graph"></div>
 <!-- Disables context menu which appears after right-clicking -->
 <script src="scripts/disable-context-menu.js" defer></script>
 <!-- Activates popover from Bootstrap -->
 <script src="scripts/enables-popover.js" defer></script>
 <!-- Setups switch for managing physics and activates tooltip from Bootstrap -->
-<script src="scripts/setup-switch-with-tooltip.js" defer></script>
+<script src="scripts/setup-tools.js" defer></script>
 <!-- Interactive binding graph displayed on the page -->
 <script src="scripts/binding_graph.js" defer></script>
 <!-- Tries to execute a query and highlights its name when it is valid -->

--- a/project/src/com/google/daggerqueryui/res/clear-button-icon.svg
+++ b/project/src/com/google/daggerqueryui/res/clear-button-icon.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" viewBox="-128 -128 744 744" xmlns="http://www.w3.org/2000/svg">
+ <g transform="translate(0 -540.36)">
+  <g transform="matrix(.93969 .34202 -.34202 .93969 288.96 -29.281)" stroke-miterlimit=".5">
+   <path transform="matrix(1.6441 -2.7919 -2.8197 -1.5958 278.45 1529)" d="m254.1 122.62c0 32.669-26.483 59.152-59.152 59.152s-59.152-26.483-59.152-59.152 26.483-59.152 59.152-59.152c3.4435 0 6.8804 0.30069 10.272 0.89865" fill="none" stroke="#dadada" stroke-linecap="square" stroke-width="30.866"/>
+   <path transform="matrix(2.4143 -4.39 3.3006 1.9982 -1050.7 900.01)" d="m169.74 286.71 43.096-0.19189-21.382 37.418z" fill="#dadada" stroke-width="0"/>
+  </g>
+ </g>
+</svg>

--- a/project/src/com/google/daggerqueryui/scripts/setup-tools.js
+++ b/project/src/com/google/daggerqueryui/scripts/setup-tools.js
@@ -27,3 +27,7 @@ $(function () {
     bindingGraph.draw();
   });
 })
+
+$("#clear-icon").click(function(){
+  bindingGraph.clear();
+});


### PR DESCRIPTION
Adds button for clearing the entire graph.

Using an icon from [Pixabay](https://pixabay.com/vectors/refresh-update-icon-reload-renew-525698/#).

**Main changes:**
* Extended css by adding styles for a new button.
* Placed a `clear` button in the bottom-right of the page.

![Screen Recording 2020-09-22 at 12 39 37](https://user-images.githubusercontent.com/19249980/93866943-06c29000-fcd1-11ea-9c5a-0c24dd0b3ff0.gif)

__P.S. Strange traces on the gif appear due to the conversion of mov to gif, they are not visible when using the site.__