### PR TITLE
Adds command for opening a website to the bash script

### DIFF
--- a/project/dagger-query-ui-example.sh
+++ b/project/dagger-query-ui-example.sh
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-bazel run src/com/google/daggerquery:example_java_server
-
+open src/com/google/daggerqueryui/index.html
+bazel run ${1:-src/com/google/daggerquery:example_java_server}


### PR DESCRIPTION
Adds command for opening a website by executing the bash script.

User needs to pass the path to the server target. Otherwise, an example target will be executed as a default.