### PR TITLE
Browsing history 🔑

### DIFF
--- a/project/src/com/google/daggerqueryui/scripts/analyze-input-field-content.js
+++ b/project/src/com/google/daggerqueryui/scripts/analyze-input-field-content.js
@@ -187,9 +187,19 @@ const historyManager = (function() {
 })();
 
 $("#query-input").on('keyup', function (event) {
+  const queryNameElement = $(this).closest('.interactive-input-container').find('.query-name');
+
   if (event.key === 'ArrowUp') {
     try {
-      $(this).val(historyManager.getPreviousQuery());
+      const previousQuery = historyManager.getPreviousQuery();
+      const queryName = previousQuery.split(' ')[0];
+      $(this).val(previousQuery);
+
+      if ($(this).validateQueryName(queryName)) {
+        queryNameElement.html(queryName).show();
+      } else {
+        queryNameElement.hide();
+      }
     } catch (error) {
       console.log(error)
     }
@@ -197,7 +207,15 @@ $("#query-input").on('keyup', function (event) {
     return;
   } else if (event.key === 'ArrowDown') {
     try {
-      $(this).val(historyManager.getNextQuery());
+      const nextQuery = historyManager.getNextQuery();
+      const queryName = nextQuery.split(' ')[0];
+      $(this).val(nextQuery);
+
+      if ($(this).validateQueryName(queryName)) {
+        queryNameElement.html(queryName).show();
+      } else {
+        queryNameElement.hide();
+      }
     } catch (error) {
       console.log(error)
     }
@@ -208,7 +226,6 @@ $("#query-input").on('keyup', function (event) {
   const query = $(this).val().trim().split(' ');
   const queryName = query[0].toLowerCase();
 
-  const queryNameElement = $(this).closest('.interactive-input-container').find('.query-name');
   if (!$(this).validateQueryName(queryName)) {
     queryNameElement.hide();
 


### PR DESCRIPTION
Adds logic for browsing history of executed queries.

**Approach:** Let's save all executed queries in one array and create a **pointer** that is always equal to the index of the last query shown (and -1 at the beginning). When the user clicks the `up arrow`, we are taking the query that was executed before the one indicated by the **pointer**. Otherwise, if the user clicks the `down arrow`, we execute the next query. 

When the user makes a new query, we reset the pointer.

![Screen-Recording-2020-09-23-at-17 15 57](https://user-images.githubusercontent.com/19249980/94025873-a9f2d280-fdc1-11ea-8d94-f01687ffe219.gif)

The logic is quite similar to the one which is used by terminal.

[Card](https://github.com/googleinterns/dagger-query/projects/2#card-44227229)