### PR TITLE
Removes arrays with expected output from tests

### DIFF
--- a/project/src/com/google/daggerqueryui/tests/binding-graph-test.js
+++ b/project/src/com/google/daggerqueryui/tests/binding-graph-test.js
@@ -56,13 +56,9 @@ describe('Binding Graph', function() {
   it('removes all deps and isolated nodes correctly', function() {
     bindingGraph.addDeps('com.google.A', ['com.google.B', 'com.google.C', 'com.google.D']);
 
-    const expectedNodes = [
-      [0, 'A', 'com.google.A'],
-    ];
-
     bindingGraph.deleteDeps('com.google.A');
 
-    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), [[0, 'A', 'com.google.A']]);
     assert.isOk(bindingGraph.getEdges().length === 0);
   });
 
@@ -70,21 +66,11 @@ describe('Binding Graph', function() {
     bindingGraph.addDeps('com.google.A', ['com.google.B']);
     bindingGraph.addDeps('com.google.C', ['com.google.B', 'com.google.D']);
 
-    const expectedNodes = [
-      [0, 'A', 'com.google.A'],
-      [1, 'B', 'com.google.B'],
-      [2, 'C', 'com.google.C'],
-      [3, 'D', 'com.google.D'],
-    ];
-    const expectedEdges = [
-      [2, 1],
-      [2, 3],
-    ];
-
     bindingGraph.deleteDeps('com.google.A');
 
-    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
-    assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]), expectedEdges);
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]),
+        [[0, 'A', 'com.google.A'], [1, 'B', 'com.google.B'], [2, 'C', 'com.google.C'], [3, 'D', 'com.google.D']]);
+    assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]), [[2, 1], [2, 3]]);
   });
 
   it('removes all ancestors and isolated nodes correctly', function() {
@@ -92,13 +78,9 @@ describe('Binding Graph', function() {
     bindingGraph.addDeps('com.google.C', ['com.google.B']);
     bindingGraph.addDeps('com.google.D', ['com.google.B']);
 
-    const expectedNodes = [
-      [1, 'B', 'com.google.B'],
-    ];
-
     bindingGraph.deleteAncestors('com.google.B');
 
-    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), [[1, 'B', 'com.google.B']]);
     assert.isOk(bindingGraph.getEdges().length === 0);
   });
 
@@ -106,18 +88,10 @@ describe('Binding Graph', function() {
     bindingGraph.addDeps('com.google.A', ['com.google.B', 'com.google.C']);
     bindingGraph.addDeps('com.google.C', ['com.google.B']);
 
-    const expectedNodes = [
-      [0, 'A', 'com.google.A'],
-      [1, 'B', 'com.google.B'],
-      [2, 'C', 'com.google.C'],
-    ];
-    const expectedEdges = [
-      [0, 2],
-    ];
-
     bindingGraph.deleteAncestors('com.google.B');
 
-    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]), expectedNodes);
-    assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]), expectedEdges);
+    assert.sameDeepMembers(bindingGraph.getNodes().map(node => [node.id, node.label, node.title]),
+        [[0, 'A', 'com.google.A'], [1, 'B', 'com.google.B'], [2, 'C', 'com.google.C']]);
+    assert.sameDeepMembers(bindingGraph.getEdges().map(node => [node.from, node.to]), [[0, 2]]);
   });
 });

--- a/project/src/com/google/daggerqueryui/tests/tests-runner.html
+++ b/project/src/com/google/daggerqueryui/tests/tests-runner.html
@@ -27,7 +27,7 @@
 <!-- Vis.js library -->
 <script src="../third-party/js/vis-network.min.js"></script>
 <!-- Interactive binding graph displayed on the page -->
-<script src="../scripts/binding_graph.js"></script>
+<script src="../scripts/binding-graph.js"></script>
 <!-- Binding graph tests -->
 <script src="binding-graph-test.js"></script>
 


### PR DESCRIPTION
Changes frontend tests by removing arrays with expected output and changing the name of binding graph file.

<img width="1217" alt="Screenshot 2020-09-29 at 11 13 27" src="https://user-images.githubusercontent.com/19249980/94531431-3a5b6800-0245-11eb-9c1b-6af8a5af3e7f.png">
