### PR TITLE
Highlights all paths instead of one

### DIFF
--- a/project/src/com/google/daggerqueryui/scripts/analyze-input-field-content.js
+++ b/project/src/com/google/daggerqueryui/scripts/analyze-input-field-content.js
@@ -111,9 +111,7 @@ const queryExecutor = (function() {
         if (query[0] === $.DEPS_QUERY_NAME) {
           bindingGraph.addDeps(query[1], results);
         } else if (query[0] === $.ALLPATHS_QUERY_NAME || query[0] === $.SOMEPATH_QUERY_NAME) {
-          for (const path of results) {
-            bindingGraph.addPath(path);
-          }
+          bindingGraph.addPaths(results);
         } else if (query[0] === $.RDEPS_QUERY_NAME) {
           bindingGraph.addAncestors(query[1], results);
         } else if (query[0] === $.EXISTS_QUERY_NAME) {

--- a/project/src/com/google/daggerqueryui/scripts/binding-graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding-graph.js
@@ -319,33 +319,50 @@ const bindingGraph = (function() {
     });
   }
 
-  return {
-    /**
-     * Takes a string representing a path where two adjacent nodes are connected by an edge,
-     * and adds all these edges to the subgraph.
-     *
-     * <p>Given path is separated with ' -> ' arrow.
-     *
-     * <p>If the path is invalid and contains less than two nodes, the method does nothing.
-     *
-     * @param {string} path a valid string representing a path with at least two nodes
-     */
-    addPath: function (path) {
-      const nodesInPath = path.split( ' -> ');
-      if (nodesInPath.length < 2) {
-        return;
-      }
+  /**
+   * Takes a string representing a path where two adjacent nodes are connected by an edge,
+   * and adds all these edges to the subgraph.
+   *
+   * <p>Given path is separated with ' -> ' arrow.
+   *
+   * <p>If the path is invalid and contains less than two nodes, the method does nothing.
+   *
+   * @param {string} path
+   * @param {string} baseColor
+   * @param {string} highlightColor
+   */
+  function addPath(path, baseColor, highlightColor) {
+    const nodesInPath = path.split( ' -> ');
+    if (nodesInPath.length < 2) {
+      return;
+    }
 
+    addEdge(nodesInPath[0], nodesInPath[1], new EdgeStyle(EdgeType.highlightSource, baseColor, highlightColor));
+    for (let index = 1; index + 2 < nodesInPath.length; ++index) {
+      addEdge(nodesInPath[index], nodesInPath[index + 1], new EdgeStyle(EdgeType.noHighlight, baseColor, highlightColor));
+    }
+    addEdge(nodesInPath[nodesInPath.length - 2], nodesInPath[nodesInPath.length - 1],
+      new EdgeStyle(EdgeType.highlightTarget, baseColor, highlightColor));
+  }
+
+  return {
+
+
+    /**
+     * Takes an array with paths and draws all of them.
+     *
+     * <p>All given paths are separated with ' -> ' arrow.
+     *
+     * @param {string[]} paths an array with valid paths between nodes in the graph
+     */
+    addPaths: function (paths) {
       recolourAllNodes(GRAY_COLOR);
 
       const baseColor = extractColor();
       const highlightColor = extractColor();
-      addEdge(nodesInPath[0], nodesInPath[1], new EdgeStyle(EdgeType.highlightSource, baseColor, highlightColor));
-      for (let index = 1; index + 2 < nodesInPath.length; ++index) {
-        addEdge(nodesInPath[index], nodesInPath[index + 1], new EdgeStyle(EdgeType.noHighlight, baseColor, highlightColor));
+      for (const path of paths) {
+        addPath(path, baseColor, highlightColor);
       }
-      addEdge(nodesInPath[nodesInPath.length - 2], nodesInPath[nodesInPath.length - 1],
-        new EdgeStyle(EdgeType.highlightTarget, baseColor, highlightColor));
     },
 
     /**

--- a/project/src/com/google/daggerqueryui/scripts/binding-graph.js
+++ b/project/src/com/google/daggerqueryui/scripts/binding-graph.js
@@ -356,8 +356,6 @@ const bindingGraph = (function() {
      * @param {string[]} paths an array with valid paths between nodes in the graph
      */
     addPaths: function (paths) {
-      recolourAllNodes(GRAY_COLOR);
-
       const baseColor = extractColor();
       const highlightColor = extractColor();
       for (const path of paths) {


### PR DESCRIPTION
Highlights all paths instead of one after executing `allpaths` query.

Since we have a public function which adds **one path** only it recolours the latest path which was shown. Let's create a public function which takes an **array with paths** and avoid recolouring all previous nodes with grey each time.

**Before:**
<img width="1185" alt="Screenshot 2020-09-30 at 21 41 28" src="https://user-images.githubusercontent.com/19249980/94726596-23606700-0366-11eb-8612-85558c8c79f5.png">

**After:**
<img width="1220" alt="Screenshot 2020-09-30 at 21 39 28" src="https://user-images.githubusercontent.com/19249980/94726602-252a2a80-0366-11eb-8db6-c1d45a05ee62.png">